### PR TITLE
Norm messaging extensions

### DIFF
--- a/msteams-platform/TOC.yml
+++ b/msteams-platform/TOC.yml
@@ -99,7 +99,7 @@
         href: ./resources/design/framework/search
       - name: Tabs
         href: ./resources/design/framework/tabs
-      - name: Compose extensions
+      - name: Messaging extensions
         href: ./resources/design/framework/compose-extensions
       - name: Bots
         href: ./resources/design/framework/bots

--- a/msteams-platform/concepts/apps/apps-overview.md
+++ b/msteams-platform/concepts/apps/apps-overview.md
@@ -20,7 +20,7 @@ After you decide what your app should do, you can map those activities to capabi
 
 *	For simple information display or interaction with web-based data, consider using [**tabs**](~/concepts/tabs/tabs-overview). Your tabs can be as simple as documents or notes or as rich as dashboards with data visualization, or design canvases.
 *	For natural-language questions and lightweight tasks, consider using [**bots**](~/concepts/bots/bots-overview). Your bots might monitor and control build systems, schedule meetings or travel, or quickly gather information from team members. Notification-only bots can push relevant information directly to a specific user in a channel or a direct message.
-*	To look up information and insert it directly into a conversation, consider using [**compose extensions**](~/concepts/compose-extensions). With compose extensions, you enable users to insert text, links, pictures, videos, and other rich media without switching to another app.
+*	To look up information and insert it directly into a conversation, consider using [**messaging extensions**](~/concepts/compose-extensions). With messaging extensions, you enable users to insert text, links, pictures, videos, and other rich media without switching to another app.
 
 ## Leverage what you've already built
 
@@ -29,9 +29,9 @@ The following table provides a few ideas about bringing resources you've already
 | If I have an existing&hellip; | In Microsoft Teams it can be a&hellip; |
 | --- | --- |
 | Web app | [Tab](~/concepts/tabs/tabs-overview) |
-| Bot built with Bot Framework | [Bot](~/concepts/bots/bots-overview) (and a [compose extension](~/concepts/compose-extensions), if you'd like)
+| Bot built with Bot Framework | [Bot](~/concepts/bots/bots-overview) (and a [Messaging extension](~/concepts/compose-extensions), if you'd like)
 | Office 365 Connector | [Connector](~/concepts/connectors) |
-| Web service (to look up information) | [Compose extension](~/concepts/compose-extensions) |
+| Web service (to look up information) | [Messaging extension](~/concepts/compose-extensions) |
 | Outgoing webhook | [Custom bot](~/concepts/custom-bot) |
 
 ## Learn how to develop an app for Microsoft Teams
@@ -45,7 +45,7 @@ Ready to start adding your experience into Teams?
   * [Tabs](~/concepts/tabs/tabs-overview)
   * [Bots](~/concepts/bots/bots-overview)
   * [Connectors](~/concepts/connectors)
-  * [Compose extensions](~/concepts/compose-extensions)
+  * [Messaging extensions](~/concepts/compose-extensions)
   * [Activity feed integrations](~/concepts/activity-feed)
 * Package, test, and publish your app
   * [Package your app](~/publishing/apps-package)

--- a/msteams-platform/concepts/apps/apps-sideload.md
+++ b/msteams-platform/concepts/apps/apps-sideload.md
@@ -82,11 +82,11 @@ With the app loaded in the team, users can set up a Connector on any channel in 
 
   ![The Add a tab dialog box, featuring a gallery of available tabs.](~/assets/images/connector_gallery.png)
 
-## Accessing your sideloaded compose extension
+## Accessing your sideloaded messaging extension
 
-A sideloaded app with a compose extension automatically appears in the **More options** (**&#8943;**) menu in the compose box.
+A sideloaded app with a messaging extension automatically appears in the **More options** (**&#8943;**) menu in the compose box.
 
-![Compose extensions](~/assets/images/compose-extensions/cesampleapp.png)
+![Messaging extensions](~/assets/images/compose-extensions/cesampleapp.png)
 
 ## Removing or updating your app
 

--- a/msteams-platform/concepts/bots/bots-overview.md
+++ b/msteams-platform/concepts/bots/bots-overview.md
@@ -19,7 +19,7 @@ Other than its hexagonal avatar icon, a bot appears just like any other team mem
 
 Bots in Teams can surface in a one-on-one context ("personal scope"), as a member of a team ("team scope"), or both. For the latter, they take part in a conversation only when you @mention them. For the former, you can address them via the conversation interface or access them in the apps personal experience from the app bar flyout.
 
-With Microsoft Teams apps, you can make the bot the star of your experience, or just a helper. Bots are distributed as part of your broader app package, which can include other capabilities such as tabs or compose extensions.
+With Microsoft Teams apps, you can make the bot the star of your experience, or just a helper. Bots are distributed as part of your broader app package, which can include other capabilities such as tabs or messaging extensions.
 
 If your bot is the star, be sure to take advantage of the [tabs](~/concepts/tabs/tabs-overview) capability as well. Use this rich web view to surface accompanying experiences and information that helps your users best interact with your service.
 
@@ -29,7 +29,7 @@ We want to make development of Microsoft Teams apps as easy as possible, so we b
 
 * Using specialized card types like the Office 365 Connector card
 * Consuming and setting Teams-specific channel data on activities
-* Processing compose extension requests
+* Processing messaging extension requests
 * Handling rate limiting
 
 The SDK extensions install dependencies, including the Bot Builder SDK.

--- a/msteams-platform/concepts/bots/bots-test.md
+++ b/msteams-platform/concepts/bots/bots-test.md
@@ -49,7 +49,7 @@ There are two ways to test load your bot for 1:1 conversations in Microsoft Team
    * Optionally, in the Bot Framework's details Channels page, you can click "Get bot embed codes" and select the Microsoft Teams icon to get both the deep link and a Microsoft Teams&ndash;approved logo for use on your website.
 
 > [!NOTE]
-> When a bot has been added through one of these methods, it will not be addressable in channel conversations. Nor can you take advantage of other Microsoft Teams app capabilities like tabs or compose extensions.
+> When a bot has been added through one of these methods, it will not be addressable in channel conversations. Nor can you take advantage of other Microsoft Teams app capabilities like tabs or messaging extensions.
 
 As with bots added to a team, your bot will receive the `conversationUpdate` event, but without the team information in the `channelData` object.
 

--- a/msteams-platform/concepts/compose-extensions.md
+++ b/msteams-platform/concepts/compose-extensions.md
@@ -45,7 +45,7 @@ As with bots and tabs, you update the [manifest](~/resources/schema/manifest-sch
 
 #### Declare your messaging extension
 
-To add a messaging extension, include a new top-level JSON structure in your manifest with the `composeExtensions` property. Currently, you are limited to creating a single messaging extension for your app.
+To add a messaging extension, include a new top-level JSON structure in your manifest with the `composeExtensions` property. Currently, you are limited to creating a single messaging extension for your app. Note that the manifest refers to messaging extensions as composeExtensions.  This is to maintain backwards compatibility.
 
 The extension definition is an object that has the following structure:
 

--- a/msteams-platform/concepts/compose-extensions.md
+++ b/msteams-platform/concepts/compose-extensions.md
@@ -45,7 +45,9 @@ As with bots and tabs, you update the [manifest](~/resources/schema/manifest-sch
 
 #### Declare your messaging extension
 
-To add a messaging extension, include a new top-level JSON structure in your manifest with the `composeExtensions` property. Currently, you are limited to creating a single messaging extension for your app. Note that the manifest refers to messaging extensions as composeExtensions.  This is to maintain backwards compatibility.
+To add a messaging extension, include a new top-level JSON structure in your manifest with the `composeExtensions` property. Currently, you are limited to creating a single messaging extension for your app. 
+> [!NOTE]
+>The manifest refers to messaging extensions as `composeExtensions`.  This is to maintain backwards compatibility.
 
 The extension definition is an object that has the following structure:
 

--- a/msteams-platform/concepts/compose-extensions.md
+++ b/msteams-platform/concepts/compose-extensions.md
@@ -1,20 +1,20 @@
 ---
-title: Develop compose extensions
-description: Describes how to get started with compose extensions in Microsoft Teams
-keywords: teams compose extensions
+title: Develop messaging extensions
+description: Describes how to get started with messaging extensions in Microsoft Teams
+keywords: teams messaging extensions messaging extensions
 ---
-# Preview: Develop compose extensions for Microsoft Teams
+# Preview: Develop messaging extensions for Microsoft Teams
 
-Compose extensions are a powerful new way for users to engage with your app within Microsoft Teams. With this capability, users can query for information from your service and post that information, in the form of rich cards, right into the channel conversation.
+Messaging extensions are a powerful new way for users to engage with your app within Microsoft Teams. With this capability, users can query for information from your service and post that information, in the form of rich cards, right into the channel conversation.
 
 > [!IMPORTANT]
-> Compose extensions are available only in [Public Developer Preview](~/resources/general/developer-preview). Many details in this document are subject to change.
+> messaging extensions are available only in [Public Developer Preview](~/resources/general/developer-preview). Many details in this document are subject to change.
 
-![Example of compose extension card](~/assets/images/compose-extensions/ceexample.png)
+![Example of messaging extension card](~/assets/images/compose-extensions/ceexample.png)
 
-Compose extensions appear along the bottom of the compose box. A few are built in, such as Emoji, Giphy, and Sticker. Choose the **More Options** (**&#8943;**) button to see other compose extensions, including those that you add from the app gallery or sideload yourself.
+Messaging extensions appear along the bottom of the compose box. A few are built in, such as Emoji, Giphy, and Sticker. Choose the **More Options** (**&#8943;**) button to see other messaging extensions, including those that you add from the app gallery or sideload yourself.
 
-How would you use compose extensions? Here are a few possibilities:
+How would you use messaging extensions? Here are a few possibilities:
 
 * Work items and bugs
 * Customer support tickets
@@ -22,30 +22,30 @@ How would you use compose extensions? Here are a few possibilities:
 * Images and media content
 * Sales opportunities and leads
 
-## Add a compose extension to your app
+## Add a messaging extension to your app
 
-Building a compose extension involves implementing familiar Microsoft Teams developer-platform concepts like bot APIs, rich cards, and tabs.
+Building a messaging extension involves implementing familiar Microsoft Teams developer-platform concepts like bot APIs, rich cards, and tabs.
 
-At its core, a compose extension is a cloud-hosted service that listens to user requests and responds with structured data, such as cards. You integrate your service with Microsoft Teams via Bot Framework `Activity` objects. Our .NET and Node.js [extensions for the Bot Builder SDK](~/get-started/code#microsoft-teams-extensions-for-the-bot-builder-sdk) can help you add compose extension functionality to your app.
+At its core, a messaging extension is a cloud-hosted service that listens to user requests and responds with structured data, such as cards. You integrate your service with Microsoft Teams via Bot Framework `Activity` objects. Our .NET and Node.js [extensions for the Bot Builder SDK](~/get-started/code#microsoft-teams-extensions-for-the-bot-builder-sdk) can help you add messaging extension functionality to your app.
 
-![Diagram of message flow for compose extensions](~/assets/images/compose-extensions/ceflow.png)
+![Diagram of message flow for messaging extensions](~/assets/images/compose-extensions/ceflow.png)
 
 ### Register in the Bot Framework
 
-If you haven’t done so already, you must first register a bot with the Microsoft Bot Framework. (See [Create a bot](~/concepts/bots/bots-create) for instructions.) The Microsoft app ID and callback endpoints for your bot, as defined there, will be used in your compose extension to receive and respond to user requests. Remember to enable the Microsoft Teams channel for your bot.
+If you haven’t done so already, you must first register a bot with the Microsoft Bot Framework. (See [Create a bot](~/concepts/bots/bots-create) for instructions.) The Microsoft app ID and callback endpoints for your bot, as defined there, will be used in your messaging extension to receive and respond to user requests. Remember to enable the Microsoft Teams channel for your bot.
 
 Record your bot’s app ID and app password—you will need to supply the app ID in your app manifest.
 
 ### Update your app manifest
 
-As with bots and tabs, you update the [manifest](~/resources/schema/manifest-schema#composeextensions) of your app to include the compose extension properties. These properties govern how your compose extension appears and behaves in the Microsoft Teams client. Compose extensions are supported beginning with v1.0 of the manifest.
+As with bots and tabs, you update the [manifest](~/resources/schema/manifest-schema#composeextensions) of your app to include the messaging extension properties. These properties govern how your messaging extension appears and behaves in the Microsoft Teams client. Messaging extensions are supported beginning with v1.0 of the manifest.
 
 > [!NOTE]
-> The `canUpdateConfiguration` property is not yet included in the manifest schema. However, you can still test compose extensions that use `canUpdateConfiguration` by sideloading them.
+> The `canUpdateConfiguration` property is not yet included in the manifest schema. However, you can still test messaging extensions that use `canUpdateConfiguration` by sideloading them.
 
-#### Declare your compose extension
+#### Declare your messaging extension
 
-To add a compose extension, include a new top-level JSON structure in your manifest with the `composeExtensions` property. Currently, you are limited to creating a single compose extension for your app.
+To add a messaging extension, include a new top-level JSON structure in your manifest with the `composeExtensions` property. Currently, you are limited to creating a single messaging extension for your app.
 
 The extension definition is an object that has the following structure:
 
@@ -54,13 +54,13 @@ The extension definition is an object that has the following structure:
 | `botId` | The unique Microsoft app ID for the bot as registered with the Bot Framework. This should typically be the same as the ID for your overall Teams app. | Yes |
 | `scopes` | Array declaring whether this extension can be added to `personal` or `team` scopes (or both). | Yes |
 | `canUpdateConfiguration` | Enables **Settings** menu item. | No |
-| `commands` | Array of commands that this compose extension supports. This is currently limited to one command. | Yes |
+| `commands` | Array of commands that this messaging extension supports. This is currently limited to one command. | Yes |
 
 #### Define commands
 
-Your compose extension should declare one command, which appears when the user selects your app from the **More options** (**&#8943;**) button in the compose box. 
+Your messaging extension should declare one command, which appears when the user selects your app from the **More options** (**&#8943;**) button in the compose box.
 
-![Screenshot of list of compose extensions in Teams](~/assets/images/compose-extensions/compose-extension-list.png)
+![Screenshot of list of messaging extensions in Teams](~/assets/images/compose-extensions/compose-extension-list.png)
 
 In the app manifest, your command item is an object with the following structure:
 
@@ -137,29 +137,29 @@ In the app manifest, your command item is an object with the following structure
  
 ### Test via sideloading
 
-You can test your compose extension by sideloading your app. See [Sideloading your app in a team](~/concepts/apps/apps-sideload) for details.
+You can test your messaging extension by sideloading your app. See [Sideloading your app in a team](~/concepts/apps/apps-sideload) for details.
 
-To open your compose extension, navigate to any of your chats or channels. Choose the **More options** (**&#8943;**) button in the compose box, and choose your compose extension.
+To open your messaging extension, navigate to any of your chats or channels. Choose the **More options** (**&#8943;**) button in the compose box, and choose your messaging extension.
 
 > [!NOTE]
 > Your app appears in channels only if you declare the `team` scope. Similarly, it appears in your chats only if it supports the `personal` scope.
 
 ## Add event handlers
 
-Most of your work involves the `onQuery` event, which handles all interactions in the compose extension window.
+Most of your work involves the `onQuery` event, which handles all interactions in the messaging extension window.
 
-If you set `canUpdateConfiguration` to `true` in the manifest, you enable the **Settings** menu item for your compose extension and must also handle `onQuerySettingsUrl` and `onSettingsUpdate`.
+If you set `canUpdateConfiguration` to `true` in the manifest, you enable the **Settings** menu item for your messaging extension and must also handle `onQuerySettingsUrl` and `onSettingsUpdate`.
 
 > [!IMPORTANT]
-> Compose extensions that use `canUpdateConfiguration` can't be published in the Office Store at this time.
+> Messaging extensions that use `canUpdateConfiguration` can't be published in the Office Store at this time.
 
 ### Handle onQuery events
 
-A compose extension receives an `onQuery` event when anything happens in the compose extension window or is sent to the window.
+A messaging extension receives an `onQuery` event when anything happens in the messaging extension window or is sent to the window.
 
-If your compose extension uses a configuration page, your handler for `onQuery` should first check for any stored configuration information; if the compose extension isn't configured, return a `config` response with a link to your configuration page. Be aware that the response from the configuration page is also handled by `onQuery`. (The sole exception is when the configuration page is called by the handler for `onQuerySettingsUrl`; see the following section.)
+If your messaging extension uses a configuration page, your handler for `onQuery` should first check for any stored configuration information; if the messaging extension isn't configured, return a `config` response with a link to your configuration page. Be aware that the response from the configuration page is also handled by `onQuery`. (The sole exception is when the configuration page is called by the handler for `onQuerySettingsUrl`; see the following section.)
 
-If your compose extension requires authentication, check the user state information; if the user isn't signed in, follow the instructions in the [Authentication](#authentication) section later in this topic.
+If your messaging extension requires authentication, check the user state information; if the user isn't signed in, follow the instructions in the [Authentication](#authentication) section later in this topic.
 
 Next, check whether `initialRun` is set; if so, take appropriate action, such as providing instructions or a list of responses.
 
@@ -175,7 +175,7 @@ Your handler for `onQuerySettingsUrl` returns the URL for the configuration page
 
 ## Receive and respond to queries
 
-Every request to your compose extension is done via an `Activity` object that is posted to your callback URL. The request contains information about the user command, such as ID and parameter values. The request also supplies metadata about the context in which your extension was invoked, including user and tenant ID, along with chat ID or channel and team IDs.
+Every request to your messaging extension is done via an `Activity` object that is posted to your callback URL. The request contains information about the user command, such as ID and parameter values. The request also supplies metadata about the context in which your extension was invoked, including user and tenant ID, along with chat ID or channel and team IDs.
 
 ### Receive user requests
 
@@ -331,7 +331,7 @@ The result list is displayed in the Microsoft Teams UI with a preview of each it
 
 ### Default query
 
-If you set `initialRun` to `true` in the manifest, Microsoft Teams issues a "default" query when the user first opens the compose extension. Your service can respond to this query with a set of prepopulated results. This can be useful for displaying, for instance, recently viewed items, favorites, or any other information that is not dependent on user input.
+If you set `initialRun` to `true` in the manifest, Microsoft Teams issues a "default" query when the user first opens the messaging extension. Your service can respond to this query with a set of prepopulated results. This can be useful for displaying, for instance, recently viewed items, favorites, or any other information that is not dependent on user input.
 
 The default query has the same structure as any regular user query, except with a parameter `initialRun` whose Boolean value is `true`.
 
@@ -373,7 +373,7 @@ The `id` value is guaranteed to be that of the authenticated Teams user. It can 
 
 ## Authentication
 
-If your service requires user authentication, you need to sign in the user before he or she can use the compose extension. If you have written a bot or a tab that signs in the user, this section should be familiar.
+If your service requires user authentication, you need to sign in the user before he or she can use the messaging extension. If you have written a bot or a tab that signs in the user, this section should be familiar.
 
 The sequence is as follows:
 
@@ -479,7 +479,7 @@ At this point, the window closes and control is passed to the Teams client. The 
 
 ### .NET
 
-To receive and handle queries with the Bot Builder SDK for .NET, you can check for the `invoke` action type on the incoming activity and then use the helper method in the NuGet package [Microsoft.Bot.Connector.Teams](https://www.nuget.org/packages/Microsoft.Bot.Connector.Teams) to determine whether it’s a compose extension activity.
+To receive and handle queries with the Bot Builder SDK for .NET, you can check for the `invoke` action type on the incoming activity and then use the helper method in the NuGet package [Microsoft.Bot.Connector.Teams](https://www.nuget.org/packages/Microsoft.Bot.Connector.Teams) to determine whether it’s a messaging extension activity.
 
 #### Example code
 
@@ -490,7 +490,7 @@ public async Task<HttpResponseMessage> Post([FromBody]Activity activity)
     {
         if (activity.IsComposeExtensionQuery())
         {
-            // This is the response object that will get sent back to the compose extension request.
+            // This is the response object that will get sent back to the messaging extension request.
             ComposeExtensionResponse invokeResponse = null;
 
             // This helper method gets the query as an object.
@@ -517,7 +517,7 @@ public async Task<HttpResponseMessage> Post([FromBody]Activity activity)
     } else {
       // Failure case catch-all.
       var response = Request.CreateResponse(HttpStatusCode.BadRequest);
-      response.Content = new StringContent("Invalid request! This API supports only compose extension requests. Check your query and try again");
+      response.Content = new StringContent("Invalid request! This API supports only messaging extension requests. Check your query and try again");
       return response;
     }
 }
@@ -525,7 +525,7 @@ public async Task<HttpResponseMessage> Post([FromBody]Activity activity)
 
 ### Node.js
 
-The [Teams extensions](https://www.npmjs.com/package/botbuilder-teams) for the Bot Builder SDK for Node.js provide helper objects and methods to simplify receiving, processing, and responding to compose extension requests.
+The [Teams extensions](https://www.npmjs.com/package/botbuilder-teams) for the Bot Builder SDK for Node.js provide helper objects and methods to simplify receiving, processing, and responding to messaging extension requests.
 
 #### Example code
 

--- a/msteams-platform/get-started/code.md
+++ b/msteams-platform/get-started/code.md
@@ -1,19 +1,19 @@
 ---
 title: Get started
 description: Get started building great apps in Microsoft Teams
-keywords: getting started microsoft teams
+keywords: getting started Microsoft teams
 ---
 # Code your Microsoft Teams app
 
-Because Microsoft Teams apps are composed web services, you can use any web-programming technology. For tabs, we provide a JavaScript library. For bots and compose extensions, we recommend you use either C# or Typescript to take advantage of our [SDK extensions](#microsoft-teams-extensions-for-the-bot-builder-sdk) for .NET and Node.js.
+Because Microsoft Teams apps are composed web services, you can use any web-programming technology. For tabs, we provide a JavaScript library. For bots and messaging extensions, we recommend you use either C# or Typescript to take advantage of our [SDK extensions](#microsoft-teams-extensions-for-the-bot-builder-sdk) for .NET and Node.js.
 
 ## Coding your tab
 
-Tabs are simply iframe'd web content. You can leverage your existing web service, written in any language and hosted on any cloud platform, and simply include the [Microsoft Teams JavaScript client SDK](/javascript/api/overview/msteams-client) in pages you display in Teams. This library provides methods for your tab and your authentication and configuration experiences.
+Tabs are simply web content in an iframe. You can leverage your existing web service, written in any language and hosted on any cloud platform, and simply include the [Microsoft Teams JavaScript client SDK](/javascript/api/overview/msteams-client) in pages you display in Teams. This library provides methods for your tab and your authentication and configuration experiences.
 
-## Coding your bot and compose extension
+## Coding your bot and messaging extension
 
-Because your Teams bots and compose extensions are built on the [Microsoft Bot Framework](https://dev.botframework.com/), we recommend that you leverage the [Bot Builder SDK](https://docs.microsoft.com/en-us/bot-framework/resources-tools-downloads), available for .NET and for Node.js.
+Because your Teams bots and messaging extensions are built on the [Microsoft Bot Framework](https://dev.botframework.com/), we recommend that you leverage the [Bot Builder SDK](https://docs.microsoft.com/en-us/bot-framework/resources-tools-downloads), available for .NET and for Node.js.
 
 > [!NOTE]
 > You can develop in any other web-programming technology and call the [Bot Framework REST APIs](https://docs.microsoft.com/en-us/bot-framework/rest-api/bot-framework-rest-overview) directly, but you must perform all token handling yourself.
@@ -24,7 +24,7 @@ We want to make development of Microsoft Teams apps as easy as possible, so we b
 
 * Specialized Teams card types like the Office 365 Connector card
 * Consuming and setting Teams-specific channel data on activities
-* Processing compose extension requests
+* Processing messaging extension requests
 * Handling rate limiting
 
 Both packages install dependencies, including the Bot Builder SDK.

--- a/msteams-platform/get-started/design.md
+++ b/msteams-platform/get-started/design.md
@@ -48,14 +48,14 @@ In general, your bot must respond to every message, especially common questions 
 
 Leverage the [bot event messages](~/concepts/bots/bots-notifications) to ensure that your bot introduces itself when added to a team or first accessed in a one-on-one chat. This is an opportunity to tell the user what value you bring to their workday.
 
-## Designing a great compose extension
+## Designing a great messaging extension
 
-Compose extensions allow you to share rich cards in a conversation. A card can hold instructions to complete a complex task or a simple GIF. Microsoft Teams comes equipped with several compose extensions already. If you look below the compose box, you’ll see a "GIF" icon. Click it, and you’ll see a menu with options to select a featured GIF or search for a specific one—that’s a compose extension! These extensions are one of the best ways to create shareable content and serve information quickly.
+Messaging extensions allow you to share rich cards in a conversation. A card can hold instructions to complete a complex task or a simple GIF. Microsoft Teams comes equipped with several messaging extensions already. If you look below the compose box, you’ll see a "GIF" icon. Click it, and you’ll see a menu with options to select a featured GIF or search for a specific one—that’s a messaging extension! These extensions are one of the best ways to create shareable content and serve information quickly.
 
 ### Optimize your search results
 
-A snappy compose extension returns an easily digestible list of search results. We recommend including an image and no more than two lines of text.
+A snappy messaging extension returns an easily digestible list of search results. We recommend including an image and no more than two lines of text.
 
 ### Optimize your cards
 
-Each compose extension culminates in a card. Because it’s the last thing your user sees, be sure that your cards are useful, good-looking, and easy to share.
+Each messaging extension culminates in a card. Because it’s the last thing your user sees, be sure that your cards are useful, good-looking, and easy to share.

--- a/msteams-platform/get-started/get-started.md
+++ b/msteams-platform/get-started/get-started.md
@@ -77,7 +77,7 @@ With those steps out of the way, you're ready to focus on creating your app.
   * [Tabs](~/concepts/tabs/tabs-overview)
   * [Bots](~/concepts/bots/bots-overview)
   * [Connectors](~/concepts/connectors)
-  * [Compose extensions](~/concepts/compose-extensions)
+  * [Messaging extensions](~/concepts/compose-extensions)
   * [Activity feed integrations](~/concepts/activity-feed)
 
 ### Package and test your app within Teams

--- a/msteams-platform/overview.md
+++ b/msteams-platform/overview.md
@@ -30,7 +30,7 @@ In these docs, you'll find the information you need to bring your content, apps,
 
 |   |   |
 | - | - |
-| **Concepts** | Learn more about creating Teams apps, and find everything you need to know about the entire range of capabilities in Teams: tabs, bots, Connectors, compose extensions, and more. |
+| **Concepts** | Learn more about creating Teams apps, and find everything you need to know about the entire range of capabilities in Teams: tabs, bots, connectors, messaging extensions, and more. |
 | **Publishing** | Want to publish your Teams app in the Office Store? Look here for the steps and guidelines. |
 | **Scenarios** | Go deep into end-to-end scenarios. |
 | **Resources** | Find all those nitty-gritty details you need to build a Teams app, such as a design topic, or a manifest schema reference. |

--- a/msteams-platform/publishing/apps-package.md
+++ b/msteams-platform/publishing/apps-package.md
@@ -32,7 +32,7 @@ The `color` icon is used throughout Microsoft Teams (in app and tab galleries, b
 
 ### outline
 
-The `outline` icon is used in three specific places: the app bar, pinnned compose extensions, and chiclets. This icon must be 20&times;20; it needs to be a trace image using white, and use a transparent background. Here are a few good examples:
+The `outline` icon is used in three specific places: the app bar, pinnned messaging extensions, and chiclets. This icon must be 20&times;20; it needs to be a trace image using white, and use a transparent background. Here are a few good examples:
 
 ![Sample outline icons](~/assets/images/icons/sample20x20s.png)
 

--- a/msteams-platform/publishing/apps-publish.md
+++ b/msteams-platform/publishing/apps-publish.md
@@ -15,7 +15,7 @@ keywords: teams publish store office publishing
 The Office Store provides a convenient location for you to upload your Microsoft Teams app, as well as other Office 365 extensibility types such as Office add-ins and Sharepoint add-ins. To include your solution in the Office Store, you submit it to the Seller Dashboard. You need to create an individual or company account if you have not already done so for other Windows apps or Office extensibility types.
 
 > [!NOTE]
-> By developing and submitting a Microsoft Teams app, you are subject to the Bot Developer Framework [Terms of Use](https://aka.ms/bf-terms), [Privacy Policy](https://aka.ms/bf-privacy), and [Code of Conduct](https://aka.ms/bf-conduct) for bot, tab, and compose extension functionality within your app. If your app contains Office 365 Connector functionality, separate terms may also apply as part of your Connector Registration on the [Connectors Developer Dashboard](https://aka.ms/publishconnector).
+> By developing and submitting a Microsoft Teams app, you are subject to the Bot Developer Framework [Terms of Use](https://aka.ms/bf-terms), [Privacy Policy](https://aka.ms/bf-privacy), and [Code of Conduct](https://aka.ms/bf-conduct) for bot, tab, and messaging extension functionality within your app. If your app contains Office 365 Connector functionality, separate terms may also apply as part of your Connector Registration on the [Connectors Developer Dashboard](https://aka.ms/publishconnector).
 
 ## Register as an app developer
 

--- a/msteams-platform/resources/design/framework/compose-extensions.md
+++ b/msteams-platform/resources/design/framework/compose-extensions.md
@@ -1,11 +1,11 @@
 ---
 title: Design Guidelines Reference
-description: Describes the guidelines for creating compose extensions and sharing content
-keywords: teams design guidelines reference framework compose extensions
+description: Describes the guidelines for creating messaging extensions and sharing content
+keywords: teams design guidelines reference framework messaging extensions
 ---
 # Share your content in a channel or chat
 
-Compose extensions allow you to share rich cards in a conversation. A card can hold instructions to complete a complex task or a simple GIF. Microsoft Teams comes equipped with several compose extensions already. If you look below the compose box, you’ll see a “GIF” icon. That’s a compose extension! These extensions are one of the best ways to create shareable content and serve information quickly.
+Messaging extensions allow you to share rich cards in a conversation. A card can hold instructions to complete a complex task or a simple GIF. Microsoft Teams comes equipped with several messaging extensions already. If you look below the compose box, you’ll see a “GIF” icon. That’s a messaging extension! These extensions are one of the best ways to create shareable content and serve information quickly.
 
 ---
 
@@ -13,16 +13,16 @@ Compose extensions allow you to share rich cards in a conversation. A card can h
 
 ### Stick to a single parameter
 
-Compose extensions can hold up to five parameters, but we recommend limiting yourself to a single parameter as often as possible. Say you built a service that creates to-do lists. A single-parameter compose extension would search for tasks, and while searching for two parameters (like “title of task” + “assigned to me”) is possible, doing so would make your interface a lot more complicated.
+Messaging extensions can hold up to five parameters, but we recommend limiting yourself to a single parameter as often as possible. Say you built a service that creates to-do lists. A single-parameter messaging extension would search for tasks, and while searching for two parameters (like “title of task” + “assigned to me”) is possible, doing so would make your interface a lot more complicated.
 
 > [!TIP]
-> Try not to include optional parameters in your compose extension. People tend to feel obligated to fill out every parameter before they execute a search.
+> Try not to include optional parameters in your messaging extension. People tend to feel obligated to fill out every parameter before they execute a search.
 
 ### Limit card size for list results
 
 Once a user has queried your extension, they’ll be presented with a list of results. Each result in your list is presented as an individual card, and this list includes multiple preview items. Based on that setup, your results cards should be relatively small in size. Save the bulk of your information, images, and formatting for the card your user eventually clicks on at the end of their flow.
 
-### Users can select an entity from your compose extension...
+### Users can select an entity from your messaging extension...
 
 ![Selecting an entity](~/assets/images/framework/framework_message-extentions_01.png)
 
@@ -40,12 +40,12 @@ Once a user has queried your extension, they’ll be presented with a list of re
 
 ### Keep it simple
 
-A compose extension should be light-weight and fast or it will lose its utility. If your search requirements are very complex or multiple parameters are necessary even in the simplest case, it’s OK to include them. 
+A messaging extension should be light-weight and fast or it will lose its utility. If your search requirements are very complex or multiple parameters are necessary even in the simplest case, it’s OK to include them. 
 
 ### Optimize your search results
 
-A snappy compose extension will return an easily digestible list of search results. We recommend including an image and no more than two lines of text.
+A snappy messaging extension will return an easily digestible list of search results. We recommend including an image and no more than two lines of text.
 
 ### Optimize your cards
 
-Each compose extension produces in a card. Since it’s the last thing your user will see, make sure your cards are useful, good-looking, and easy to share.
+Each messaging extension produces in a card. Since it’s the last thing your user will see, make sure your cards are useful, good-looking, and easy to share.

--- a/msteams-platform/resources/design/framework/submitting.md
+++ b/msteams-platform/resources/design/framework/submitting.md
@@ -131,9 +131,9 @@ You can have one connector per app. Include a connector ID that matches its ID i
 
 ---
 
-## Compose extensions
+## Messaging extensions
 
-Specifications for each compose extension should include:
+Specifications for each messaging extension should include:
 
 ### ID
 
@@ -185,7 +185,7 @@ Define the level of encryption used in your app, if any.
 
 Provide support links.
 
-[See the compose extensions design guidelines.](compose-extensions)
+[See the messaging extensions design guidelines.](compose-extensions)
 
 Include screenshots of your app for your profile page (you can add up to five, total). Specify your language, release date, category, and pricing (again, select the ‘Free’ option here).
 

--- a/msteams-platform/resources/design/overview.md
+++ b/msteams-platform/resources/design/overview.md
@@ -41,9 +41,9 @@ The activity feed displays notifications for your users. [Learn more](~/resource
 
 <img width="530" src="~/assets/images/get-started/05_homepage_instant-notifications.png" /><br/><br/>
 
-### Compose extensions
+### Messaging extensions
 
-Compose Extensions are quick and easy shortcuts to key components of your service. [Learn more](~/resources/design/framework/compose-extensions)
+Messaging extensions are quick and easy shortcuts to key components of your service. [Learn more](~/resources/design/framework/compose-extensions)
 
 <img width="530" src="~/assets/images/get-started/06_homepage_compose-extensions.png" /><br/><br/>
 

--- a/msteams-platform/resources/general/developer-preview-features.md
+++ b/msteams-platform/resources/general/developer-preview-features.md
@@ -12,15 +12,15 @@ The following features are available in the Public Developer Preview as of Augus
 
 ## Apps in Microsoft Teams
 
-Apps in Microsoft Teams allow you to make your service available to users through a single Teams App package, which includes bots, tabs, connectors and compose extensions. Learn more [here](~/overview). 
+Apps in Microsoft Teams allow you to make your service available to users through a single Teams App package, which includes bots, tabs, connectors and messaging extensions. Learn more [here](~/overview). 
   
 ## Discover Apps gallery 
 
 The Discover Apps gallery provides a listing of all apps available in Microsoft Teams spanning various categories. Developers can get apps in here by [submitting their apps to the Office Store](~/publishing/apps-publish).  
   
-## Compose extensions
+## Messaging extensions
 
-Compose extensions make it easy for users to query for information from your service and post them into conversations in the form of rich cards. Learn more [here](~/concepts/compose-extensions).
+Messaging extensions make it easy for users to query for information from your service and post them into conversations in the form of rich cards. Learn more [here](~/concepts/compose-extensions).
    
 ## App notifications 
 

--- a/msteams-platform/resources/schema/manifest-schema.md
+++ b/msteams-platform/resources/schema/manifest-schema.md
@@ -300,19 +300,19 @@ The object is an array (maximum of 1 element) with all elements of type `object`
 
 >[Public Developer Preview](~/resources/general/developer-preview) only
 
-Defines a compose extension for the app.
+Defines a messaging extension for the app.
 
-The object is an array (maximum of 1 element) with all elements of type `object`. This block is required only for solutions that provide a compose extension.
+The object is an array (maximum of 1 element) with all elements of type `object`. This block is required only for solutions that provide a messaging extension.
 
 |Name| Type| Maximum size | Required | Description|
 |---|---|---|---|---|
-|`botId`|String|64 characters|✔|The unique Microsoft app ID for the bot that backs the compose extension, as registered with the Bot Framework. This can be the same as the overall [app ID](#id).|
+|`botId`|String|64 characters|✔|The unique Microsoft app ID for the bot that backs the messaging extension, as registered with the Bot Framework. This can be the same as the overall [app ID](#id).|
 |`scopes`|Array of enum|2|✔|Specifies whether the bot offers an experience in the context of a channel in a `team`, or an experience scoped to an individual user alone (`personal`). These options are non-exclusive.|
-|`commands`|Array of object|1|✔|Array of commands that the compose extension supports|
+|`commands`|Array of object|1|✔|Array of commands that the messaging extension supports|
 
 ### composeExtensions.commands
 
-Your compose extension should declare one or more commands. Each command appears in Microsoft Teams as a potential interaction from the UI-based entry point.
+Your messaging extension should declare one or more commands. Each command appears in Microsoft Teams as a potential interaction from the UI-based entry point.
 
 Each command item is an object with the following structure:
 

--- a/msteams-platform/samples/code-samples.md
+++ b/msteams-platform/samples/code-samples.md
@@ -1,14 +1,14 @@
 ---
 title: Sample applications
 description: Links and descriptions of sample applications for the Microsoft Teams developer platform
-keywords: microsoft teams developer samples
+keywords: Microsoft teams developer samples
 ---
 
 # Sample applications for the Microsoft Teams developer platform
 
 These code samples show you the capabilities of Microsoft Teams apps and various ways to implement those capabilities:
 
-* **[Get Started Sample](https://github.com/OfficeDev/microsoft-teams-sample-get-started)**&emsp;This sample shows all the capabilities available in a Microsoft Teams app, including bots, tabs, compose extensions, and connectors. Source code is provided in both C# and Node.js.
+* **[Get Started Sample](https://github.com/OfficeDev/microsoft-teams-sample-get-started)**&emsp;This sample shows all the capabilities available in a Microsoft Teams app, including bots, tabs, messaging extensions, and connectors. Source code is provided in both C# and Node.js.
 * **[Microsoft Graph API Samples](https://github.com/OfficeDev/microsoft-teams-sample-graph)**&emsp;These samples demonstrate using Microsoft Graph API calls to perform tasks such as querying teams and channels from a web service running outside Microsoft Teams.
 * **["To-do" list sample tab app](https://github.com/OfficeDev/microsoft-teams-sample-todo)**&emsp;This Node.js sample shows how easy it is to convert an existing web app into a tab.
 * **Microsoft Teams extensions for the Bot Builder SDK**&emsp;These sample bots show how to use the [Teams extensions for the Bot Builder SDK](https://msdn.microsoft.com/en-us/microsoft-teams/code#microsoft-teams-extensions-for-the-bot-builder-sdk).
@@ -17,7 +17,7 @@ These code samples show you the capabilities of Microsoft Teams apps and various
 
 ## Common prerequisites
 
-We recommend the following common prequisites for running our sample experiences:
+We recommend the following common prerequisites for running our sample experiences:
 
 * [An Office 365 account with access to Microsoft Teams, with sideloading enabled](~/get-started/get-started)
 * For .NET and C#:

--- a/msteams-platform/samples/code-samples.md
+++ b/msteams-platform/samples/code-samples.md
@@ -8,11 +8,6 @@ keywords: Microsoft teams developer samples
 
 These code samples show you the capabilities of Microsoft Teams apps and various ways to implement those capabilities:
 
-<<<<<<< HEAD
-* **[Get Started Sample](https://github.com/OfficeDev/microsoft-teams-sample-get-started)**&emsp;This sample shows all the capabilities available in a Microsoft Teams app, including bots, tabs, messaging extensions, and connectors. Source code is provided in both C# and Node.js.
-* **[Microsoft Graph API Samples](https://github.com/OfficeDev/microsoft-teams-sample-graph)**&emsp;These samples demonstrate using Microsoft Graph API calls to perform tasks such as querying teams and channels from a web service running outside Microsoft Teams.
-=======
->>>>>>> a7a578cb554a5f91c79834f50433d86598943404
 * **["To-do" list sample tab app](https://github.com/OfficeDev/microsoft-teams-sample-todo)**&emsp;This Node.js sample shows how easy it is to convert an existing web app into a tab.
 * **Microsoft Teams extensions for the Bot Builder SDK**&emsp;These sample bots show how to use the [Teams extensions for the Bot Builder SDK](https://msdn.microsoft.com/en-us/microsoft-teams/code#microsoft-teams-extensions-for-the-bot-builder-sdk).
   * [Sample bot for C# and .NET](https://github.com/OfficeDev/BotBuilder-MicrosoftTeams/tree/master/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot)


### PR DESCRIPTION
Changes to terminology. Compose extension changed to messaging extension.  References to composeExtensions the manifest have not been changed.