### PR TITLE
Fixing spelling error

### DIFF
--- a/msteams-platform/concepts/outgoingwebhook.md
+++ b/msteams-platform/concepts/outgoingwebhook.md
@@ -262,7 +262,7 @@ Your outgoing webhook will need to reply asynchronously to the HTTP request from
 ## Limitations
 
 * Outgoing webhooks do not have access to non-messaging APIs, such as team roster membership.
-* Outgoing webhooks cannot post into channels asynchronously; that is, not as a reply to a user message.
+* Outgoing webhooks cannot post into channels asynchronously; that is, only as a reply to a user message.
 * Although outgoing webhooks can use cards, they cannot leverage button actions like `imBack` or `invoke`.
 
 ## Samples for Outgoing webhook


### PR DESCRIPTION
Second bullet in Limitations section is contradictory to second paragraph in Send a reply - it makes more sense to say "only" instead of "not as a reply".