### PR TITLE
Melissa-Manifest-Description guidance

### DIFF
--- a/msteams-platform/resources/schema/manifest-schema-dev-preview.md
+++ b/msteams-platform/resources/schema/manifest-schema-dev-preview.md
@@ -213,8 +213,6 @@ Ensure that your description accurately describes your experience and provides i
 |`short`|80 characters|✔|A short description of your app experience, used when space is limited.|
 |`full`|4000 characters|✔|The full description of your app.|
 
-> [!IMPORTANT]
-> We currently have an issue with full descriptions longer than 256 characters. You can use a longer description in your Seller Dashboard app submission.
 
 ## icons
 

--- a/msteams-platform/resources/schema/manifest-schema.md
+++ b/msteams-platform/resources/schema/manifest-schema.md
@@ -211,7 +211,7 @@ The name of your app experience, displayed to users in the Teams experience. For
 
 Describes your app to users. For apps submitted to AppSource, these values must match the information in your AppSource entry.
 
-Ensure that your description accurately describes your experience and provides information to help potential customers understand what your experience does. You should also note, in the full description, if an external account is required for use. The values of `short` and `full` should not be the same.
+Ensure that your description accurately describes your experience and provides information to help potential customers understand what your experience does. You should also note, in the full description, if an external account is required for use. The values of `short` and `full` should not be the same.  Your short description must not be repeated within the long description and must not include any other app name.
 
 |Name| Maximum size | Required | Description|
 |---|---|---|---|

--- a/msteams-platform/troubleshoot/troubleshoot.md
+++ b/msteams-platform/troubleshoot/troubleshoot.md
@@ -79,8 +79,6 @@ Common reasons for manifest read errors:
 * Encoding issues. Use UTF-8 for the *manifest.json* file. Other encodings, specifically with the BOM, may not be readable.
 * Malformed .zip package. The *manifest.json* file must be at the top level of the .zip file. Note that default Mac file compression might place the *manifest.json* in a subdirectory, which will not properly load in Microsoft Teams.
 
-> [!NOTE]
-> An issue with the [description.full](~/resources/schema/manifest-schema#developer) field in the manifest causes a loading error with a string longer than 256 characters.
 
 ### Another extension with same ID exists
 


### PR DESCRIPTION
Additional guidance on "descriptions" in manifest + deletion of no longer valid "256-character-limit" notes on 2 pages