### PR TITLE
[DRAFT] Documentation for compose extension create scenarios

### DIFF
--- a/msteams-platform/concepts/messaging-extensions.md
+++ b/msteams-platform/concepts/messaging-extensions.md
@@ -6,7 +6,7 @@ ms.date: 08/15/18
 ---
 # Develop messaging extensions for Microsoft Teams
 
-Messaging extensions are a powerful new way for users to engage with your app within Microsoft Teams. With this capability, users can query for information from your service and post that information, in the form of cards, right into the channel conversation.
+Messaging extensions are a powerful new way for users to engage with your app within Microsoft Teams. With this capability, users can query or post information to and from your service and post that information, in the form of cards, right into a message.
 
 ![Example of messaging extension card](~/assets/images/compose-extensions/ceexample.png)
 

--- a/msteams-platform/concepts/messaging-extensions.md
+++ b/msteams-platform/concepts/messaging-extensions.md
@@ -282,7 +282,7 @@ The request parameters itself are found in the value object, which includes the 
 
 ### Respond to user requests
 
-When the user performs a query, Microsoft Teams issues a synchronous HTTP request to your service. At that point, your code has 5 seconds to provide an HTTP response to the request. During this time, your service can perform additional lookup, or any other business logic needed to serve the request.
+When the user performs a command, Microsoft Teams issues a synchronous HTTP request to your service. At that point, your code has 5 seconds to provide an HTTP response to the request. During this time, your service can perform additional lookup, or any other business logic needed to serve the request. In the case of `action` commands the application can also chain dialogs using `task` response mentioned below.
 
 Your service should respond with the results matching the user query. The response must indicate an HTTP status code of `200 OK` and a valid application/json object with the following body:
 

--- a/msteams-platform/resources/dev-preview/developer-preview-features.md
+++ b/msteams-platform/resources/dev-preview/developer-preview-features.md
@@ -9,6 +9,9 @@ ms.date: 09/26/2018
 When these features are out of developer preview this content will be merged into the live doc set.
 The developer preview includes the following new features:
 
+## Action based commands for Messaging Extensions
+The messaging extension infrastructure is being updated to include non-search based commands. This can be used to collect input from a user and make an update to your service. Possible exampls include: Create a task, Create a workitem, Queue a build and so on. The [messaging extension section](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/messaging-extensions) has been updated to reflect the new changes. 
+
 ## Introducing "task modules"
 
 A task module allows you to create modal popup experiences in your Teams application, from both bots and tabs. Inside the popup, you can run your own custom HTML/JavaScript code, show an `<iframe>`-based widget such as a YouTube or Microsoft Stream video, or display an [Adaptive card](https://docs.microsoft.com/en-us/adaptive-cards/).

--- a/msteams-platform/whats-new.md
+++ b/msteams-platform/whats-new.md
@@ -12,6 +12,7 @@ The change log lists changes to the Microsoft Teams platform and this document s
 
 | **Date** | **Notes** | **Changed topics** |
 | -------- | --------- | ------------------ |
+| 11/05/2018 | Action based command support for messaging extensions | [Messaging Extensions](~/concepts/compose-extensions) |
 | 10/05/2018 | Formatting information for cards has been updated, and tested in the desktop, iOS and Android clients for Teams. | [Cards](~/concepts/cards/cards), [Card formatting](~/concepts/cards/cards-format) |
 | 09/26/2018 | The "Task modules" capability was released to Developer Preview. | [Task modules overview](~/concepts/task-modules/task-modules-overview), [Using task modules in tabs](~/concepts/task-modules/task-modules-tabs), [Using task modules in bots](~/concepts/task-modules/task-modules-bots) |
 | 09/24/2018 | Calls and online meetings APIs for Microsoft Graph were released to beta, and Teams apps can now interact with users in rich ways using voice and video. | [Calls and online meetings bots](~/concepts/calls-and-meetings/calls-meetings-bots-overview), [Real-time media concepts](~/concepts/calls-and-meetings/real-time-media-concepts), [Registering a calling bot](~/concepts/calls-and-meetings/register-calling-bot), [Debugging and local testing](~/concepts/calls-and-meetings/debugging-local-testing-calling-meeting-bots), [Application-hosted media](~/concepts/calls-and-meetings/requirements-considerations-application-hosted-media-bots), [Handling incoming call notifications](~/concepts/calls-and-meetings/call-notifications) |


### PR DESCRIPTION
Creating the initial draft documentation for compose extension create scenarios. Added the changes to the command and parameters structures in the manifest as well as the new response types supported.