### PR TITLE
Clarifying Bot Framework version in Teams auth guide

### DIFF
--- a/msteams-platform/concepts/authentication/auth-oauth-card.md
+++ b/msteams-platform/concepts/authentication/auth-oauth-card.md
@@ -46,6 +46,8 @@ Because access tokens are sensitive information, you may not wish to have them s
 
 ## Getting started with OAuthCard in Teams
 
+> This guide is using the Bot Framework v3 SDK. You can find the v4 implementation [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=csharp). You will still need to create a manifest and include token.botframework.com in the `validDomains` section, because otherwise the Sign in button will not open the authentication window. Use the [App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) to generate your manifest!
+
 You’ll first need to configure your Azure bot service to set up external authentication providers. Read [Configuring identity providers](~/concepts/authentication/auth-configure) for detailed steps.
 
 To enable authentication using the Azure Bot Service, you need to make these additions to your code:

--- a/msteams-platform/concepts/authentication/auth-oauth-card.md
+++ b/msteams-platform/concepts/authentication/auth-oauth-card.md
@@ -2,7 +2,7 @@
 title: Using the OAuthCard for authentication
 description: Describes the Azure Bot Service OAuthCard and how it is used for authentication
 keywords: teams authentication OAuthCard OAuth card Azure Bot Service
-ms.date: 07/17/2018
+ms.date: 01/22/2019
 ---
 # Using Azure Bot Service for Authentication in Teams
 

--- a/msteams-platform/concepts/authentication/auth-oauth-card.md
+++ b/msteams-platform/concepts/authentication/auth-oauth-card.md
@@ -46,7 +46,7 @@ Because access tokens are sensitive information, you may not wish to have them s
 
 ## Getting started with OAuthCard in Teams
 
-> This guide is using the Bot Framework v3 SDK. You can find the v4 implementation [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=csharp). You will still need to create a manifest and include token.botframework.com in the `validDomains` section, because otherwise the Sign in button will not open the authentication window. Use the [App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) to generate your manifest!
+[!Note] This guide is using the Bot Framework v3 SDK. You can find the v4 implementation [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=csharp). You will still need to create a manifest and include token.botframework.com in the `validDomains` section, because otherwise the Sign in button will not open the authentication window. Use the [App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) to generate your manifest!
 
 You’ll first need to configure your Azure bot service to set up external authentication providers. Read [Configuring identity providers](~/concepts/authentication/auth-configure) for detailed steps.
 

--- a/msteams-platform/concepts/authentication/auth-oauth-card.md
+++ b/msteams-platform/concepts/authentication/auth-oauth-card.md
@@ -46,7 +46,7 @@ Because access tokens are sensitive information, you may not wish to have them s
 
 ## Getting started with OAuthCard in Teams
 
-[!Note] This guide is using the Bot Framework v3 SDK. You can find the v4 implementation [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=csharp). You will still need to create a manifest and include token.botframework.com in the `validDomains` section, because otherwise the Sign in button will not open the authentication window. Use the [App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) to generate your manifest!
+[!Note] This guide is using the Bot Framework v3 SDK. You can find the v4 implementation [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=csharp). You will still need to create a manifest and include token.botframework.com in the `validDomains` section, because otherwise the Sign in button will not open the authentication window. Use the [App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) to generate your manifest.
 
 You’ll first need to configure your Azure bot service to set up external authentication providers. Read [Configuring identity providers](~/concepts/authentication/auth-configure) for detailed steps.
 


### PR DESCRIPTION
Adding a clarifying message saying that the guide is for Bot Framework v3 SDK, and a link pointing to the v4 implementation.