### PR TITLE
Update the `Microsoft.Bot.Connector.Teams` package to version 0.9.0

### DIFF
--- a/msteams-platform/get-started/get-started-dotnet-app-studio.md
+++ b/msteams-platform/get-started/get-started-dotnet-app-studio.md
@@ -62,7 +62,12 @@ git clone https://github.com/OfficeDev/msteams-samples-hello-world-csharp.git
 
 ## Build and run the sample
 
-Once the repo is cloned, use Visual Studio to open the solution file `Microsoft.Teams.Samples.HelloWorld.sln` from the root directory of the sample and click `Build Solution` from the `Build` menu. You can run the sample by pressing `F5` or choosing `Start Debugging` from the `Debug` menu.
+Once the repo is cloned, use Visual Studio to open the solution file `Microsoft.Teams.Samples.HelloWorld.sln` from the root directory of the sample. 
+
+> [!TIP]
+> It is the good time to update the NuGet packages as a precaution. At least, please update the `Microsoft.Bot.Connector.Teams` package to version 0.9.0 minimum.
+
+Click `Build Solution` from the `Build` menu. You can run the sample by pressing `F5` or choosing `Start Debugging` from the `Debug` menu.
 
 When the app starts, you will see a browser window open with the root of the app launched. You can navigate to the following URLs to verify that all the app URLs are loading:
 


### PR DESCRIPTION
…inimum.

The errors the users get for the Bot and the Messaging Extensions are because of old NuGet packages versions.
I had the sample not working either for the Bot and the Messaging Extensions before I upgraded  `Microsoft.Bot.Connector.Teams` to v0.9.0