### PR TITLE
Bot Builder V4 works with Teams bots

### DIFF
--- a/msteams-platform/concepts/bots/bots-create.md
+++ b/msteams-platform/concepts/bots/bots-create.md
@@ -8,9 +8,6 @@ ms.date: 12/07/2018
 
 All bots created using the Microsoft Bot Framework are configured and ready to work in Microsoft Teams.
 
->[!Note]
->These steps require Bot Framework version 3. The Bot Framework documentation has been updated to version 4, which does not work with Teams.
-
 A sample bot is included in the [Get Started](~/get-started/get-started.md) sample for Node.js and .NET, along with detailed steps for creating your first bot.
 
 See the [Bot Framework Documentation](https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-3.0) for general information on bots.

--- a/msteams-platform/concepts/bots/bots-create.md
+++ b/msteams-platform/concepts/bots/bots-create.md
@@ -7,7 +7,7 @@ ms.date: 12/07/2018
 # Create a bot
 
 >[!Note]
->Both v3 and v4 bots built on the Bot Framework work with Microsoft Teams. However, the [Teams Bot Builder SDKs](/microsoftteams/platform/#pivot=sdk-tools) for v4 bots are in beta. The documentation in this section follow the patterns for v3 bots. For v4 guidance, see the samples included in the SDK repositories.
+>Both v3 and v4 bots built on the Bot Framework work with Microsoft Teams. However, the [Teams Bot Builder SDKs](/microsoftteams/platform/#pivot=sdk-tools) for v4 bots are in beta. The documentation in this section follows the patterns for v3 bots. For v4 guidance, see the samples included in the SDK repositories.
 
 All bots created using the Microsoft Bot Framework are configured and ready to work in Microsoft Teams.
 

--- a/msteams-platform/concepts/bots/bots-create.md
+++ b/msteams-platform/concepts/bots/bots-create.md
@@ -6,6 +6,9 @@ ms.date: 12/07/2018
 ---
 # Create a bot
 
+>[!Note]
+>Both v3 and v4 bots built on the Bot Framework work with Microsoft Teams. However, the [Teams Bot Builder SDKs](/microsoftteams/platform/#pivot=sdk-tools) for v4 bots are in beta. The documentation in this section follow the patterns for v3 bots. For v4 guidance, see the samples included in the SDK repositories.
+
 All bots created using the Microsoft Bot Framework are configured and ready to work in Microsoft Teams.
 
 A sample bot is included in the [Get Started](~/get-started/get-started.md) sample for Node.js and .NET, along with detailed steps for creating your first bot.


### PR DESCRIPTION
Remove the note stating Bot Framework v4 does not work with Teams.