### PR TITLE
Fixed broken link

### DIFF
--- a/msteams-platform/resources/dev-preview/developer-preview-features.md
+++ b/msteams-platform/resources/dev-preview/developer-preview-features.md
@@ -10,6 +10,6 @@ The developer preview includes the following new features:
 
 ## Calls and online meeting bots
 
-With the addition of [Microsoft Graph APIs for calls and online meetings](https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/calls-api-overview.md), Microsoft Teams apps can now interact with users in rich ways using voice and video. These APIs allow you to add new app features such as interactive voice response (IVR), call control, and access to real-time audio and/or video streams for calls and meetings, including desktop and app sharing.
+With the addition of [Microsoft Graph APIs for calls and online meetings](https://docs.microsoft.com/en-us/graph/api/resources/calls-api-overview), Microsoft Teams apps can now interact with users in rich ways using voice and video. These APIs allow you to add new app features such as interactive voice response (IVR), call control, and access to real-time audio and/or video streams for calls and meetings, including desktop and app sharing.
 
 We've added a new section on how to create and develop calls and online meetings bots, starting with the [overview](~/concepts/calls-and-meetings/calls-meetings-bots-overview.md).

--- a/msteams-platform/resources/dev-preview/developer-preview-features.md
+++ b/msteams-platform/resources/dev-preview/developer-preview-features.md
@@ -10,6 +10,6 @@ The developer preview includes the following new features:
 
 ## Calls and online meeting bots
 
-With the addition of [Microsoft Graph APIs for calls and online meetings](https://docs.microsoft.com/en-us/graph/api/resources/calls-api-overview), Microsoft Teams apps can now interact with users in rich ways using voice and video. These APIs allow you to add new app features such as interactive voice response (IVR), call control, and access to real-time audio and/or video streams for calls and meetings, including desktop and app sharing.
+With the addition of [Microsoft Graph APIs for calls and online meetings](/graph/api/resources/calls-api-overview), Microsoft Teams apps can now interact with users in rich ways using voice and video. These APIs allow you to add new app features such as interactive voice response (IVR), call control, and access to real-time audio and/or video streams for calls and meetings, including desktop and app sharing.
 
 We've added a new section on how to create and develop calls and online meetings bots, starting with the [overview](~/concepts/calls-and-meetings/calls-meetings-bots-overview.md).


### PR DESCRIPTION
On the page https://docs.microsoft.com/en-us/microsoftteams/platform/resources/dev-preview/developer-preview-features

The link for "Microsoft Graph APIs for calls and online meetings" is broken. It is pointed to page https://docs.microsoft.com/en-us/graph/api/resources/calls-api-overview