### PR TITLE
Cards with mention support dev preview documentation

### DIFF
--- a/msteams-platform/resources/dev-preview/developer-preview-features.md
+++ b/msteams-platform/resources/dev-preview/developer-preview-features.md
@@ -8,6 +8,10 @@ keywords: teams preview developer features
 
 The developer preview includes the following new features:
 
+## Mention support in Adaptive cards
+
+You can now add @ mentions within an Adaptive card body for Bots and Messaging Extension responses. @ mentions in cards follow the same notification logic and rendering as that of a regular message based mentions. Note that card based mentions are only supported in Web and Desktop clients today, with support for rendering in mobile clients coming soon.
+
 ## Tabs Single Sign-On
 
 You can now use [single sign-on (SSO)](~/tabs/how-to/authentication/auth-aad-sso.md) to login and authenticate a user on desktop and mobile using the Teams JavaScript SDK from a web content page. One of the benefits is that a user never has to sign-in; and once they've consented to the app using their profile: they will automatically be signed-in to their tab (including mobile).

--- a/msteams-platform/task-modules-and-cards/cards/cards-format.md
+++ b/msteams-platform/task-modules-and-cards/cards/cards-format.md
@@ -113,6 +113,8 @@ To include a mention in an Adaptive Card your app needs to include the following
 * `<at>username</at>` in the supported adaptive card elements
 * The `mention` object inside of an `msteams` property in the card content, which includes the Teams user id of the user being mentioned
 
+Note that cards with mentions aren't supported on mobile clients at the moment.
+
 ### Sample Adaptive card with a mention
 ``` json
 {

--- a/msteams-platform/task-modules-and-cards/cards/cards-format.md
+++ b/msteams-platform/task-modules-and-cards/cards/cards-format.md
@@ -103,7 +103,7 @@ The date and localization features mentioned in this topic are not supported in 
 ## Mention support within Adaptive cards 
 
 > [!NOTE]
-> Mention support in cards is currently supported in _Developer Preview_ only.
+> Mention support in cards is currently supported in [Developer Preview](~/resources/dev-preview/developer-preview-intro) only.
 
 Bots and Messaging extensions can now include mentions within the card content in Text Block and FactSet elements. 
 

--- a/msteams-platform/task-modules-and-cards/cards/cards-format.md
+++ b/msteams-platform/task-modules-and-cards/cards/cards-format.md
@@ -100,6 +100,48 @@ The date and localization features mentioned in this topic are not supported in 
     ]
 }
 ```
+## Mention support within Adaptive cards 
+
+> [!NOTE]
+> Mention support in cards is currently supported in _Developer Preview_ only.
+
+Bots and Messaging extensions can now include mentions within the card content in Text Block and FactSet elements. 
+
+### Constructing mentions
+To include a mention in an Adaptive Card your app needs to include the following elements
+
+* `<at>username</at>` in the supported adaptive card elements
+* The `mention` object inside of an `msteams` property in the card content, which includes the Teams user id of the user being mentioned
+
+### Sample Adaptive card with a mention
+``` json
+{
+  "contentType": "application/vnd.microsoft.card.adaptive",
+  "content": {
+    "type": "AdaptiveCard",
+    "body": [
+      {
+        "type": "TextBlock",
+        "text": "Hi <at>John Doe</at>"
+      }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.0",
+    "msteams": {
+      "entities": [
+        {
+          "type": "mention",
+          "text": "<at>John Doe</at>",
+          "mentioned": {
+            "id": "29:123124124124",
+            "name": "John Doe"
+          }
+        }
+      ]
+    }
+  }
+}
+```
 
 ## HTML formatting for Connector Cards
 

--- a/msteams-platform/task-modules-and-cards/cards/design-effective-cards.md
+++ b/msteams-platform/task-modules-and-cards/cards/design-effective-cards.md
@@ -124,6 +124,6 @@ Anything that needs to be read by a user should be included in a text field. Onc
 ### Use mentions if you want the attention of specific users
 
 > [!NOTE]
-> Mention support in cards is currently supported in _Developer Preview_ only.
+> Mention support in cards is currently supported in [Developer Preview](~/resources/dev-preview/developer-preview-intro.md) only.
 
 Mentions are a great way to notify specific users in a Team or group chat. You can include a mention in card in scenarios like, a task thats assigned to a user or giving Kudos to a teammate. Learn how to include mentions in cards in the [card formatting page](~/task-modules-and-cards/cards/cards-format.md). 

--- a/msteams-platform/task-modules-and-cards/cards/design-effective-cards.md
+++ b/msteams-platform/task-modules-and-cards/cards/design-effective-cards.md
@@ -120,3 +120,10 @@ Graphics are going to scale, so be sure to preview them on all platforms.
 ### Avoid including text in a graphic
 
 Anything that needs to be read by a user should be included in a text field. Once an image is dynamically scaled, any text you add to a graphic may become unintelligible.
+
+### Use mentions if you want the attention of specific users
+
+> [!NOTE]
+> Mention support in cards is currently supported in _Developer Preview_ only.
+
+Mentions are a great way to notify specific users in a Team or group chat. You can include a mention in card in scenarios like, a task thats assigned to a user or giving Kudos to a teammate. Learn how to include mentions in cards in the [card formatting page](~/task-modules-and-cards/cards/cards-format.md). 

--- a/msteams-platform/task-modules-and-cards/cards/design-effective-cards.md
+++ b/msteams-platform/task-modules-and-cards/cards/design-effective-cards.md
@@ -1,5 +1,5 @@
 ---
-title: DDesigning effective cards
+title: Designing effective cards
 description: Describes the design guidelines for creating cards
 keywords: teams design guidelines reference framework cards adaptable lightweight
 ---


### PR DESCRIPTION
Documentation for cards with mention support which is now in developer preview. Following files have been modified 
* Developer preview feature list
* Formatting card text
* Designing effective cards