### PR TITLE
Adaptive 1.2 Dev preview update

### DIFF
--- a/msteams-platform/resources/dev-preview/developer-preview-features.md
+++ b/msteams-platform/resources/dev-preview/developer-preview-features.md
@@ -8,6 +8,10 @@ keywords: teams preview developer features
 
 The developer preview includes the following new features:
 
+## Adaptive 1.2 Support
+
+Microsoft Teams now supports [Adaptive version 1.2](https://github.com/microsoft/AdaptiveCards/releases/tag/v1.2.0) in Developer Preview. Note that [Media elements](https://adaptivecards.io/explorer/Media.html) aren't supported yet.
+
 ## Tabs Single Sign-On
 
 You can now use [single sign-on (SSO)](~/tabs/how-to/authentication/auth-aad-sso.md) to login and authenticate a user on desktop and mobile using the Teams JavaScript SDK from a web content page. One of the benefits is that a user never has to sign-in; and once they've consented to the app using their profile: they will automatically be signed-in to their tab (including mobile).

--- a/msteams-platform/task-modules-and-cards/cards/cards-reference.md
+++ b/msteams-platform/task-modules-and-cards/cards/cards-reference.md
@@ -62,7 +62,7 @@ See [Card Formatting](~/task-modules-and-cards/cards/cards-format.md) for more i
 ## Adaptive card
 
 > [!NOTE]
-> Only version 1.0 of Adaptive Cards is supported.
+> Only version 1.0 of Adaptive Cards is supported for all users. Version 1.2 is currently available only in Developer Preview
 
 A customizable card that can contain any combination of text, speech, images, buttons, and input fields.
 


### PR DESCRIPTION
Added a note in the Developer preview feature list calling out support for Adaptive cards 1.2. Also updated the note in card references to say that we now support 1.2 in developer preview.