### PR TITLE
add user permissions on mobile info

### DIFF
--- a/msteams-platform/tabs/how-to/native-device-permissions.md
+++ b/msteams-platform/tabs/how-to/native-device-permissions.md
@@ -15,6 +15,16 @@ You might want to enrich your tab with features that require access native devic
 
 ![Device Permissions settings screen](~/assets/images/tabs/device-permissions.png)
 
+> [!IMPORTANT]
+> Full support for tabs on mobile clients is coming soon. To prepare for this change you should follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md) when creating your tabs. Personal apps (static tabs) are currently available in [developer preview](~/resources/dev-preview/developer-preview-intro.md).
+>
+> When full support for tabs is released:
+>
+> * All tabs will always be available on mobile
+> * Your `contentUrl` **will be loaded in the mobile Teams client**.
+> * For channel/group tabs, users can still open your tab in a separate browser via your `websiteUrl`, however your `contentUrl` will be loaded first.  
+> * User permissions for native device functionality on mobile platforms will be configured in your app's **app manifest** (Android) or **Info.plist** (iOS) file.
+
 ## Device permissions
 
 Accessing a user’s device permissions allows you to build much richer experiences, for example:

--- a/msteams-platform/tabs/how-to/native-device-permissions.md
+++ b/msteams-platform/tabs/how-to/native-device-permissions.md
@@ -16,7 +16,7 @@ You might want to enrich your tab with features that require access native devic
 ![Device Permissions settings screen](~/assets/images/tabs/device-permissions.png)
 
 > [!IMPORTANT]
-> Full support for tabs on mobile clients is coming soon. To prepare for this change you should follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md) when creating your tabs. Personal apps (static tabs) are currently available in [developer preview](~/resources/dev-preview/developer-preview-intro.md).
+> Native device functionality is currently not supported for tabs on mobile clients but full support is coming soon. To prepare for this change you should follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md) when creating your tabs. Personal apps (static tabs) are currently available in [developer preview](~/resources/dev-preview/developer-preview-intro.md).
 >
 > When full support for tabs is released:
 >

--- a/msteams-platform/tabs/how-to/native-device-permissions.md
+++ b/msteams-platform/tabs/how-to/native-device-permissions.md
@@ -23,7 +23,6 @@ You might want to enrich your tab with features that require access native devic
 > * All tabs will always be available on mobile
 > * Your `contentUrl` **will be loaded in the mobile Teams client**.
 > * For channel/group tabs, users can still open your tab in a separate browser via your `websiteUrl`, however your `contentUrl` will be loaded first.  
-> * User permissions for native device functionality on mobile platforms will be configured in your app's **app manifest** (Android) or **Info.plist** (iOS) file.
 
 ## Device permissions
 


### PR DESCRIPTION
@clearab 

I added this line to the bulleted list  in the IMPORTANT code block:

> * User permissions for native device functionality on mobile platforms will be configured in your app's **app manifest** (Android) or **Info.plist** (iOS) file.