### PR TITLE
Removed "notification only bot" restriction

### DIFF
--- a/msteams-platform/resources/bot-v3/bots-notification-only.md
+++ b/msteams-platform/resources/bot-v3/bots-notification-only.md
@@ -1,16 +1,16 @@
 ---
-title: Notification only bots
-description: Describes what notification only bots are for in Microsoft Teams
+title: Notification-only bots
+description: Describes what notification-only bots are in Microsoft Teams
 keywords: teams bots notification
 ms.date: 01/29/2020
 ---
-# Notification only bots in Microsoft Teams
+# Notification-only bots in Microsoft Teams
 
 [!include[v3-to-v4-SDK-pointer](~/includes/v3-to-v4-pointer-bots.md)]
 
 If your bot's sole purpose is to deliver notification to users and is not conversational, you can enable the `isNotificationOnly` field in your app manifest. This produces the following changes:
 
-* Users cannot message your notification only bot.
+* Users cannot message your notification-only bot.
 * Users cannot @mention the bot.
 
 ## App manifest
@@ -39,4 +39,4 @@ To enable this, set `isNotificationOnly` to `true`.
 
 ## Best practices and limitations
 
-* Notification only bots use proactive messaging to communicate with the user. See [Proactive messaging for bots](~/resources/bot-v3/bot-conversations/bots-conv-proactive.md) for more details.
+* Notification-only bots use proactive messaging to communicate with the user. See [Proactive messaging for bots](~/resources/bot-v3/bot-conversations/bots-conv-proactive.md) for more details.

--- a/msteams-platform/resources/bot-v3/bots-notification-only.md
+++ b/msteams-platform/resources/bot-v3/bots-notification-only.md
@@ -2,7 +2,7 @@
 title: Notification only bots
 description: Describes what notification only bots are for in Microsoft Teams
 keywords: teams bots notification
-ms.date: 05/20/2019
+ms.date: 01/29/2020
 ---
 # Notification only bots in Microsoft Teams
 
@@ -39,5 +39,4 @@ To enable this, set `isNotificationOnly` to `true`.
 
 ## Best practices and limitations
 
-* You cannot create a `personal` scoped notification only bot, as the user cannot message your notification only bot in a personal chat. This means that you can't receive a `conversationUpdate` event that would provide you with the necessary details to send a notification. Your notification only bot will only function correctly if it supports the `team` scope and is added to a team. In the team setting, your bot will have access to the necessary information to either send a notification to a channel or privately to a user.
 * Notification only bots use proactive messaging to communicate with the user. See [Proactive messaging for bots](~/resources/bot-v3/bot-conversations/bots-conv-proactive.md) for more details.


### PR DESCRIPTION
Removed the paragraph saying that personal scoped notification-only bots are not supported. This is not true.