### PR TITLE
Added notes on device permission behavior across login sessions

### DIFF
--- a/msteams-platform/tabs/how-to/native-device-permissions.md
+++ b/msteams-platform/tabs/how-to/native-device-permissions.md
@@ -101,3 +101,7 @@ Notification.requestPermission(function(result) { /* ... */ });
 ```
 
 ![Tabs device permissions prompt](~/assets/images/tabs/device-permissions-prompt.png)
+
+## Permission behavior across login sessions
+
+Native device permissions are stored per login session. This means that if you log into another instance of Teams (ex: on another computer), your device permissions from your previous sessions will not be available. Instead, you will need to re-consent to device permissions for the new login sessoin. This also means, if you log out of Teams (or switch tenants inside of Teams), your device permissions will be deleted for that previous login session. Please keep this in mind when developing native device permissions: the native capabilities you consent to are only for your _current_ login sessoin.


### PR DESCRIPTION
Summary: there has been some confusion around the expected behavior of device permissions when a user switches tenants (or logs out). I've added notes to the Native Device Permissions documentation to explain the expected behavior: permissions are stored per login session, so if you switch tenants or log out, your device permissions will not be persisted.