### PR TITLE
Update metadata for content recommendation

### DIFF
--- a/msteams-platform/tutorials/get-started-dotnet-app-studio.md
+++ b/msteams-platform/tutorials/get-started-dotnet-app-studio.md
@@ -2,6 +2,8 @@
 title: Get started with C#/.NET
 description: Get started building great apps in Microsoft Teams using C#/.NET
 keywords: getting started .net c# csharp
+ms.custom: scenarios:getting-started; languages:ASP.NET,C#
+ms.topic: tutorial
 ms.date: 11/09/2018
 ---
 

--- a/msteams-platform/tutorials/get-started-nodejs-app-studio.md
+++ b/msteams-platform/tutorials/get-started-nodejs-app-studio.md
@@ -3,6 +3,8 @@ title: Get started with App Studio and Node.js
 description: Get started building great apps in Microsoft Teams using Node.js and App Studio
 keywords: getting started node.js nodejs App Studio
 ms.date: 11/09/2018
+ms.topic: tutorial
+ms.custom: scenarios:getting-started; languages:JavaScript,Node.js
 ---
 
 # Get started on the Microsoft Teams platform with Node.js and App Studio

--- a/msteams-platform/tutorials/get-started-yeoman.md
+++ b/msteams-platform/tutorials/get-started-yeoman.md
@@ -2,6 +2,8 @@
 title: Get started with the Yeoman generator for Microsoft Teams
 description: Get started building great apps with the Yeoman generator for Microsoft Teams
 keywords: getting started node.js nodejs yeoman
+ms.topic: tutorial
+ms.custom: scenarios:getting-started
 ---
 
 # Build your First Microsoft Teams App


### PR DESCRIPTION
We are working on a feature to recommend content to Teams developers in the [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program). In order for the getting started docs to be surfaced, they need an ms.topic tag and the ms.custom tag must contain "scenarios:getting-started".

I've updated these docs with the metadata.