### PR TITLE
Updated curl sample for incoming webhooks

### DIFF
--- a/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
@@ -143,7 +143,13 @@ The following steps use [cURL](https://curl.haxx.se/). We assume that you have t
 1. From the command line, enter the following cURL command:
 
    ```bash
-   curl -H "Content-Type: application/json" -d "{\"text\": \"Hello World\"}" <YOUR WEBHOOK URL>
+   // on macOS or Linux
+   curl -H 'Content-Type: application/json' -d '{\"text\": \"Hello World\"}' <YOUR WEBHOOK URL>
+   ```
+
+   ```bash
+   // on Windows
+   curl.exe -H 'Content-Type: application/json' -d '{\"text\": \"Hello World\"}' <YOUR WEBHOOK URL>
    ```
 
 2. If the POST succeeds, you should see a simple **1** output by `curl`.


### PR DESCRIPTION
Hello,
when following the incoming webhook example on Windows the curl command execution fails as suggested right now.

The problem is related to "curl" being used as alias for the PowerShell invoke-WebRequest method. Users will receive a "Invoke-WebRequest : Cannot bind parameter 'Headers'. Cannot convert the "Content-Type: application/json" value of type "System.String" to type "System.Collections.IDictionary"." error message.

To circumvent this issue you have to explicitly call curl.exe und use single quotes instead of double quotes on a Windows machine. Therefore, I added the sample for macOS, Linux and Windows.

br,
Patrick