### PR TITLE
Provide Warning on Custom App Configuration Setting

### DIFF
--- a/msteams-platform/concepts/building-an-app.md
+++ b/msteams-platform/concepts/building-an-app.md
@@ -28,7 +28,7 @@ Once you've decided what extensibility points and features your app will take ad
 
 You need to make sure you have an environment where you can upload and test your Teams app. If you don't already have an O365 subscription with Teams enabled and the ability to upload apps to it you can [sign up for the O365 developer program](https://developer.microsoft.com/microsoft-365/dev-program) which will give you access to a free Office 365 subscription for development purposes.
 
-See [prepare your O365 environment](~/concepts/build-and-test/prepare-your-o365-tenant.md) for additional information.
+See [prepare your O365 environment](~/concepts/build-and-test/prepare-your-o365-tenant.md) for additional information. NOTE: If this is not completed, it may take hours before you are able to install your custom app.
 
 ## Build and test your app
 


### PR DESCRIPTION
If custom app settings are not set and done so correctly it may take 6 hours before changes are propagated out to users and allow for installation of custom apps.