### PR TITLE
Added links

### DIFF
--- a/msteams-platform/bots/how-to/conversations/send-proactive-messages.md
+++ b/msteams-platform/bots/how-to/conversations/send-proactive-messages.md
@@ -22,12 +22,12 @@ Sending a message to start a new conversation thread is different than sending a
 1. [Obtain the user's unique Id and tenant Id](#obtain-necessary-user-information)
 1. [Send the message](#examples)
 
-When creating proactive messages you **must** call `MicrosoftAppCredentials.TrustServiceUrl`, and pass in the service URL before creating the [`ConnectorClient`](../../../../../azure/bot-service/dotnet/bot-builder-dotnet-connector) you will use to send the message. If you do not, your app will receive a `401: Unauthorized` response.
+When creating proactive messages you **must** call `MicrosoftAppCredentials.TrustServiceUrl`, and pass in the service URL before creating the [`ConnectorClient`](/azure/bot-service/dotnet/bot-builder-dotnet-connector) you will use to send the message. If you do not, your app will receive a `401: Unauthorized` response.
 
 > [!Tip]
-> For more details on setting up the `ConnectorClient` for .NET clients, see the [Send and receive activities](../../../../../azure/bot-service/dotnet/bot-builder-dotnet-connector#create-a-connector-client) topic
+> For more details on setting up the `ConnectorClient` for .NET clients, see the [Send and receive activities](/azure/bot-service/dotnet/bot-builder-dotnet-connector#create-a-connector-client) topic
 >
-> More examples for sending proactive messages can be found in the Azure Bot Service [.NET](../../../../../azure/bot-service/dotnet/bot-builder-dotnet-proactive-messages) and [Node.js](../../../../../azure/bot-service/nodejs/bot-builder-nodejs-proactive-messages) documentation
+> More examples for sending proactive messages can be found in the Azure Bot Service [.NET](/azure/bot-service/dotnet/bot-builder-dotnet-proactive-messages) and [Node.js](/azure/bot-service/nodejs/bot-builder-nodejs-proactive-messages) documentation
 
 ## Best practices for proactive messaging
 
@@ -109,7 +109,7 @@ This ID is the personal chat's unique conversation ID. Please store this value a
 
 # [C#/.NET](#tab/dotnet)
 
-This example uses the [Microsoft.Bot.Connector.Teams](https://www.nuget.org/packages/Microsoft.Bot.Connector.Teams) NuGet package. In this example, `client` is a `ConnectorClient` instance that has already been created and authenticated as described in [Send and receive activities](../../../../../azure/bot-service/dotnet/bot-builder-dotnet-connector)
+This example uses the [Microsoft.Bot.Connector.Teams](https://www.nuget.org/packages/Microsoft.Bot.Connector.Teams) NuGet package. In this example, `client` is a `ConnectorClient` instance that has already been created and authenticated as described in [Send and receive activities](/azure/bot-service/dotnet/bot-builder-dotnet-connector)
 
 ```csharp
 // Create or get existing chat conversation with user

--- a/msteams-platform/bots/how-to/conversations/send-proactive-messages.md
+++ b/msteams-platform/bots/how-to/conversations/send-proactive-messages.md
@@ -22,7 +22,12 @@ Sending a message to start a new conversation thread is different than sending a
 1. [Obtain the user's unique Id and tenant Id](#obtain-necessary-user-information)
 1. [Send the message](#examples)
 
-When creating proactive messages you **must** call `MicrosoftAppCredentials.TrustServiceUrl`, and pass in the service URL before creating the `ConnectorClient` you will use to send the message. If you do not, your app will receive a `401: Unauthorized` response. 
+When creating proactive messages you **must** call `MicrosoftAppCredentials.TrustServiceUrl`, and pass in the service URL before creating the [`ConnectorClient`](../../../../../azure/bot-service/dotnet/bot-builder-dotnet-connector) you will use to send the message. If you do not, your app will receive a `401: Unauthorized` response.
+
+> [!Tip]
+> For more details on setting up the `ConnectorClient` for .NET clients, see the [Send and receive activities](../../../../../azure/bot-service/dotnet/bot-builder-dotnet-connector#create-a-connector-client) topic
+>
+> More examples for sending proactive messages can be found in the Azure Bot Service [.NET](../../../../../azure/bot-service/dotnet/bot-builder-dotnet-proactive-messages) and [Node.js](../../../../../azure/bot-service/nodejs/bot-builder-nodejs-proactive-messages) documentation
 
 ## Best practices for proactive messaging
 
@@ -104,7 +109,7 @@ This ID is the personal chat's unique conversation ID. Please store this value a
 
 # [C#/.NET](#tab/dotnet)
 
-This example uses the [Microsoft.Bot.Connector.Teams](https://www.nuget.org/packages/Microsoft.Bot.Connector.Teams) NuGet package.
+This example uses the [Microsoft.Bot.Connector.Teams](https://www.nuget.org/packages/Microsoft.Bot.Connector.Teams) NuGet package. In this example, `client` is a `ConnectorClient` instance that has already been created and authenticated as described in [Send and receive activities](../../../../../azure/bot-service/dotnet/bot-builder-dotnet-connector)
 
 ```csharp
 // Create or get existing chat conversation with user


### PR DESCRIPTION
Added links for readers unfamiliar with the ConnectorClient API. This is the first page I find when I search for how to send a proactive message from a bot to Teams, but it currently seems to assume I already know the details of how to create these connections using the Bot Framework SDK. Many of the details such as what URL to use for the ConnectorClient are found in the pages I've linked to here, which should save new readers some time and frustration.