### PR TITLE
Update connectors-using.md

### DIFF
--- a/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
@@ -144,12 +144,12 @@ The following steps use [cURL](https://curl.haxx.se/). We assume that you have t
 
    ```bash
    // on macOS or Linux
-   curl -H 'Content-Type: application/json' -d '{\"text\": \"Hello World\"}' <YOUR WEBHOOK URL>
+   curl -H 'Content-Type: application/json' -d '{"text": "Hello World"}' <YOUR WEBHOOK URL>
    ```
 
    ```bash
    // on Windows
-   curl.exe -H 'Content-Type: application/json' -d '{\"text\": \"Hello World\"}' <YOUR WEBHOOK URL>
+   curl.exe -H 'Content-Type: application/json' -d '{"text": "Hello World"}' <YOUR WEBHOOK URL>
    ```
 
 2. If the POST succeeds, you should see a simple **1** output by `curl`.


### PR DESCRIPTION
Fix cURL examples, that returns 'Bad payload received by generic incoming webhook.'
Fix for the issue: https://github.com/MicrosoftDocs/msteams-docs/issues/1649