### PR TITLE
Add link to permissions requirement

### DIFF
--- a/msteams-platform/bots/how-to/create-a-bot-for-teams.md
+++ b/msteams-platform/bots/how-to/create-a-bot-for-teams.md
@@ -165,9 +165,10 @@ To create an app package, you need to add your app manifest and (optionally) you
 
 ## Upload your package to Microsoft Teams
 
-If you've been using App Studio, you can install your app from the **Test and distribute** tab of the **Manifest editor**. Alternatively, you can install your app package by clicking the `...` overflow menu from the left navigation rail, clicking **More apps**, then the **Upload a custom app** link. You can also import an app manifest or app package into App Studio to make additional updates before uploading.
+> [!NOTE]
+> To successfully upload your bot, your tenant admin must first [allow uploading](/microsoftteams/manage-apps#manage-org-wide-app-settings) third-party or custom apps in Teams.
 
-In order to install your app with either method, you need to have [permission to install a custom app](/microsoftteams/teams-custom-app-policies-and-settings).
+If you've been using App Studio, you can install your app from the **Test and distribute** tab of the **Manifest editor**. Alternatively, you can install your app package by clicking the `...` overflow menu from the left navigation rail, clicking **More apps**, then the **Upload a custom app** link. You can also import an app manifest or app package into App Studio to make additional updates before uploading.
 
 ## Next steps
 

--- a/msteams-platform/bots/how-to/create-a-bot-for-teams.md
+++ b/msteams-platform/bots/how-to/create-a-bot-for-teams.md
@@ -167,6 +167,8 @@ To create an app package, you need to add your app manifest and (optionally) you
 
 If you've been using App Studio, you can install your app from the **Test and distribute** tab of the **Manifest editor**. Alternatively, you can install your app package by clicking the `...` overflow menu from the left navigation rail, clicking **More apps**, then the **Upload a custom app** link. You can also import an app manifest or app package into App Studio to make additional updates before uploading.
 
+In order to install your app with either method, you need to have [permission to install a custom app](https://docs.microsoft.com/en-us/microsoftteams/teams-custom-app-policies-and-settings).
+
 ## Next steps
 
 * [Bot conversation basics](./conversations/conversation-basics.md)

--- a/msteams-platform/bots/how-to/create-a-bot-for-teams.md
+++ b/msteams-platform/bots/how-to/create-a-bot-for-teams.md
@@ -167,7 +167,7 @@ To create an app package, you need to add your app manifest and (optionally) you
 
 If you've been using App Studio, you can install your app from the **Test and distribute** tab of the **Manifest editor**. Alternatively, you can install your app package by clicking the `...` overflow menu from the left navigation rail, clicking **More apps**, then the **Upload a custom app** link. You can also import an app manifest or app package into App Studio to make additional updates before uploading.
 
-In order to install your app with either method, you need to have [permission to install a custom app](../../../teams-custom-app-policies-and-settings).
+In order to install your app with either method, you need to have [permission to install a custom app](/microsoftteams/teams-custom-app-policies-and-settings).
 
 ## Next steps
 

--- a/msteams-platform/bots/how-to/create-a-bot-for-teams.md
+++ b/msteams-platform/bots/how-to/create-a-bot-for-teams.md
@@ -167,7 +167,7 @@ To create an app package, you need to add your app manifest and (optionally) you
 
 If you've been using App Studio, you can install your app from the **Test and distribute** tab of the **Manifest editor**. Alternatively, you can install your app package by clicking the `...` overflow menu from the left navigation rail, clicking **More apps**, then the **Upload a custom app** link. You can also import an app manifest or app package into App Studio to make additional updates before uploading.
 
-In order to install your app with either method, you need to have [permission to install a custom app](https://docs.microsoft.com/en-us/microsoftteams/teams-custom-app-policies-and-settings).
+In order to install your app with either method, you need to have [permission to install a custom app](../../../teams-custom-app-policies-and-settings).
 
 ## Next steps
 


### PR DESCRIPTION
Added a link to the page detailing the policies that govern whether installing a custom app is permitted to avoid security errors.