### PR TITLE
Fix broken markdown in "What are Bots" documentation.

### DIFF
--- a/msteams-platform/bots/what-are-bots.md
+++ b/msteams-platform/bots/what-are-bots.md
@@ -15,7 +15,7 @@ The GIF below shows a user conversing with a bot in a one-to-one chat using both
 
 ## Build  a bot for Teams with the Microsoft Bot Framework
 
-The Microsoft Bot Framework](https://dev.botframework.com/) is a rich SDK for building bots using C#, Java, Python, and JavaScript. If you already have a bot that's based on the Bot Framework, you can easily adapt it to work in Microsoft Teams. We recommend you use either C# or Node.js to take advantage of our [SDKs](/microsoftteams/platform/#pivot=sdk-tools). These packages extend the basic Bot Builder SDK classes and methods as follows:
+The [Microsoft Bot Framework](https://dev.botframework.com/) is a rich SDK for building bots using C#, Java, Python, and JavaScript. If you already have a bot that's based on the Bot Framework, you can easily adapt it to work in Microsoft Teams. We recommend you use either C# or Node.js to take advantage of our [SDKs](/microsoftteams/platform/#pivot=sdk-tools). These packages extend the basic Bot Builder SDK classes and methods as follows:
 
 * Use specialized card types like the Office 365 Connector card.
 * Consume and set Teams-specific channel data on activities.


### PR DESCRIPTION
The markdown for the link to Microsoft Bot Framework wasn't well formatted in the "What Are Bots?" documentation, so the link wasn't rendering correctly.