### PR TITLE
Update .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -21,7 +21,7 @@
         "template_folder": "_themes"
     }],
     "JoinTOCPlugin": [{
-        "ConceptualTOC": "/msteams-platform/TOC.yml",
+        "ConceptualTOC": "msteams-platform/TOC.yml",
         "ReferenceTOCUrl": "/javascript/api/msteams-client-docs-ref-typescript/toc.json?view=msteams-client-js-latest"
     }],
     "notification_subscribers": [],


### PR DESCRIPTION
`ConceptualTOC` should be relative path to repo root.
DocFX v3 is more strict about config format, we found this during the testing of migration to v3.

@TianqiZhang @herohua