### PR TITLE
Added loading indicator docs

### DIFF
--- a/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
+++ b/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
@@ -62,15 +62,15 @@ Ensure that the all URL domains used in your tabs are included in the `validDoma
 
 ## Showing a native loading indicator
 
-Starting with manifest v1.7, you can provide a native loading indicator for your web content on desktop. You need to implement the following APIs wherever your web content is loaded in Teams to hide the loading indicator (tab content, tab config dialog, tab remove dialog, task module, etc).
+Starting with [manifest schema v1.7](../../../resources/schema/manifest-schema.md), you can provide a [native loading indicator](../../../resources/schema/manifest-schema.md#showloadingindicator) wherever your web content is loaded in Teams, e.g., [tab content page](#integrate-your-code-with-teams), [configuration page](configuration-page.md), [removal page](removal-page.md) and [task modules in tabs](../../../task-modules-and-cards/task-modules-tabs.md).
 
-1. To show the loading indicator, add `"showLoadingIndicator": true` in your manifest. Teams will always show a loading indicator when your app begins loading.
-2. Remember to call `microsoftTeams.initialize();`. 
-3. (This is an optional API) If you're ready to print to the screen and wish to lazy load the rest of your application's content, you can manually hide the loading indicator by you calling `microsoftTeams.appInitialization.notifyAppLoaded();`
-4. (This is a mandatory API) Finally, you should call `microsoftTeams.appInitialization.notifySuccess()` to notify Teams that your app has successfully loaded. We will then hide the loading indicator if applicable. If you don't call `notifySuccess` within 30 seconds, we will assume your app timed out and show an error screen with a retry option.
-5. If your application fails to load, you can call `microsoftTeams.appInitialization.notifyFailure(reason);` to let us know there was an error. We will then show an error screen to the user.
+1. To show the loading indicator, add `"showLoadingIndicator": true` to your manifest. 
+2. Remember to call `microsoftTeams.initialize();`.
+3. **Optional**. If you're ready to print to the screen and wish to lazy load the rest of your application's content, you can manually hide the loading indicator by calling `microsoftTeams.appInitialization.notifyAppLoaded();`
+4. **Mandatory**. Finally, call `microsoftTeams.appInitialization.notifySuccess()` to notify Teams that your app has successfully loaded. Teams will then hide the loading indicator if applicable. If  `notifySuccess`  is not called within 30 seconds, it will be assumed that your app timed out and an error screen with a retry option will appear.
+5. If your application fails to load, you can call `microsoftTeams.appInitialization.notifyFailure(reason);` to let Teams know there was an error. An error screen will then be shown to the user:
 
-``` JSON
+```json
 /* List of failure reasons */
 export const enum FailedReason {
     AuthFailed = "AuthFailed",
@@ -78,3 +78,4 @@ export const enum FailedReason {
     Other = "Other"
 }
 ```
+>

--- a/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
+++ b/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
@@ -62,7 +62,7 @@ Ensure that the all URL domains used in your tabs are included in the `validDoma
 
 ## Showing a native loading indicator
 
-Starting with manifest v1.7, you can provide a native loading indicator for your web content on desktop. You need to implement the following APIs wherever your web content is loaded in Teams to hide the loading indicator (ie: tab content, tab config dialog, tab remove dialog, task module, etc).
+Starting with manifest v1.7, you can provide a native loading indicator for your web content on desktop. You need to implement the following APIs wherever your web content is loaded in Teams to hide the loading indicator (tab content, tab config dialog, tab remove dialog, task module, etc).
 
 1. To show the loading indicator, add `"showLoadingIndicator": true` in your manifest. Teams will always show a loading indicator when your app begins loading.
 2. Remember to call `microsoftTeams.initialize();`. 
@@ -71,7 +71,7 @@ Starting with manifest v1.7, you can provide a native loading indicator for your
 5. If your application fails to load, you can call `microsoftTeams.appInitialization.notifyFailure(reason);` to let us know there was an error. We will then show an error screen to the user.
 
 ``` JSON
-/* List of failure reason */
+/* List of failure reasons */
 export const enum FailedReason {
     AuthFailed = "AuthFailed",
     Timeout = "Timeout",

--- a/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
+++ b/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
@@ -64,13 +64,17 @@ Ensure that the all URL domains used in your tabs are included in the `validDoma
 
 Starting with [manifest schema v1.7](../../../resources/schema/manifest-schema.md), you can provide a [native loading indicator](../../../resources/schema/manifest-schema.md#showloadingindicator) wherever your web content is loaded in Teams, e.g., [tab content page](#integrate-your-code-with-teams), [configuration page](configuration-page.md), [removal page](removal-page.md) and [task modules in tabs](../../../task-modules-and-cards/task-modules-tabs.md).
 
+> [!NOTE]
+> If you indicate  `"showLoadingIndicator : true`  in your app manifest, then all tab configuration, content, and removal pages and all iframe-based task modules must follow the mandatory protocol, below:
+
 1. To show the loading indicator, add `"showLoadingIndicator": true` to your manifest. 
 2. Remember to call `microsoftTeams.initialize();`.
 3. **Optional**. If you're ready to print to the screen and wish to lazy load the rest of your application's content, you can manually hide the loading indicator by calling `microsoftTeams.appInitialization.notifyAppLoaded();`
 4. **Mandatory**. Finally, call `microsoftTeams.appInitialization.notifySuccess()` to notify Teams that your app has successfully loaded. Teams will then hide the loading indicator if applicable. If  `notifySuccess`  is not called within 30 seconds, it will be assumed that your app timed out and an error screen with a retry option will appear.
 5. If your application fails to load, you can call `microsoftTeams.appInitialization.notifyFailure(reason);` to let Teams know there was an error. An error screen will then be shown to the user:
 
-```json
+```typescript
+``
 /* List of failure reasons */
 export const enum FailedReason {
     AuthFailed = "AuthFailed",

--- a/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
+++ b/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
@@ -67,7 +67,7 @@ Starting with manifest v1.7, you can provide a native loading indicator for your
 1. To show the loading indicator, add `"showLoadingIndicator": true` in your manifest. Teams will always show a loading indicator when your app begins loading.
 2. Remember to call `microsoftTeams.initialize();`. 
 3. (This is an optional API) If you're ready to print to the screen and wish to lazy load the rest of your application's content, you can manually hide the loading indicator by you calling `microsoftTeams.appInitialization.notifyAppLoaded();`
-4. (This is a mandatory API) Finally, you should call `microsoftTeams.appInitialization.notifySuccess()` to notify Teams that your app has successfully loaded. We will then hide the loading indicator if applicable.
+4. (This is a mandatory API) Finally, you should call `microsoftTeams.appInitialization.notifySuccess()` to notify Teams that your app has successfully loaded. We will then hide the loading indicator if applicable. If you don't call `notifySuccess` within 30 seconds, we will assume your app timed out and show an error screen with a retry option.
 5. If your application fails to load, you can call `microsoftTeams.appInitialization.notifyFailure(reason);` to let us know there was an error. We will then show an error screen to the user.
 
 ``` JSON

--- a/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
+++ b/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
@@ -59,3 +59,22 @@ A task module is a modal popup-like experience that you can trigger from your ta
 ### Valid Domains
 
 Ensure that the all URL domains used in your tabs are included in the `validDomains` array in your [manifest](~/concepts/build-and-test/apps-package.md). For more information, see [validDomains](~/resources/schema/manifest-schema.md#validdomains) in the manifest schema reference. However, be mindful that the core functionality of your tab exists within Teams and not outside of Teams.
+
+## Showing a native loading indicator
+
+Starting with manifest v1.7, you can provide a native loading indicator for your web content on desktop. You need to implement the following APIs wherever your web content is loaded in Teams to hide the loading indicator (ie: tab content, tab config dialog, tab remove dialog, task module, etc).
+
+1. To show the loading indicator, add `"showLoadingIndicator": true` in your manifest. Teams will always show a loading indicator when your app begins loading.
+2. Remember to call `microsoftTeams.initialize();`. 
+3. (This is an optional API) If you're ready to print to the screen and wish to lazy load the rest of your application's content, you can manually hide the loading indicator by you calling `microsoftTeams.appInitialization.notifyAppLoaded();`
+4. (This is a mandatory API) Finally, you should call `microsoftTeams.appInitialization.notifySuccess()` to notify Teams that your app has successfully loaded. We will then hide the loading indicator if applicable.
+5. If your application fails to load, you can call `microsoftTeams.appInitialization.notifyFailure(reason);` to let us know there was an error. We will then show an error screen to the user.
+
+``` JSON
+/* List of failure reason */
+export const enum FailedReason {
+    AuthFailed = "AuthFailed",
+    Timeout = "Timeout",
+    Other = "Other"
+}
+```

--- a/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
+++ b/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
@@ -62,7 +62,7 @@ Ensure that the all URL domains used in your tabs are included in the `validDoma
 
 ## Showing a native loading indicator
 
-Starting with [manifest schema v1.7](../../../resources/schema/manifest-schema.md), you can provide a [native loading indicator](../../../resources/schema/manifest-schema.md#showloadingindicator) wherever your web content is loaded in Teams, e.g., [tab content page](#integrate-your-code-with-teams), [configuration page](configuration-page.md), [removal page](removal-page.md) and [task modules in tabs](../../../task-modules-and-cards/task-modules-tabs.md).
+Starting with [manifest schema v1.7](../../../resources/schema/manifest-schema.md), you can provide a [native loading indicator](../../../resources/schema/manifest-schema.md#showloadingindicator) wherever your web content is loaded in Teams, e.g., [tab content page](#integrate-your-code-with-teams), [configuration page](configuration-page.md), [removal page](removal-page.md) and [task modules in tabs](../../../task-modules-and-cards/task-modules/task-modules-tabs.md).
 
 > [!NOTE]
 > If you indicate  `"showLoadingIndicator : true`  in your app manifest, then all tab configuration, content, and removal pages and all iframe-based task modules must follow the mandatory protocol, below:


### PR DESCRIPTION
Added documentation on how to use the new native loading indicator for your tab.

Updated docs can be found under 
```
Tabs > How to guides > Create tab pages > Create a content page
```