### PR TITLE
Update publish.md

### DIFF
--- a/msteams-platform/concepts/deploy-and-publish/appsource/publish.md
+++ b/msteams-platform/concepts/deploy-and-publish/appsource/publish.md
@@ -22,6 +22,7 @@ Publishing  your app to [AppSource](https://appsource.microsoft.com) makes it av
 >
 >- If your Teams app contains a bot, you must comply with the Bot Developer Framework [Code of Conduct](https://aka.ms/bf-conduct).
 >- If your app contains an Office 365 Connector, additional terms may apply. *See* [Connectors Developer Dashboard](https://aka.ms/connectorsdashboard) and [App Developer Agreement](https://sellerdashboard.microsoft.com/Assets/Content/Agreements/Office_Store_Seller_Agreement_20120927.htm).
+>- To make your app available for GCC users the auth process should identify and route the user to the right content URL as opposed to having duplicate apps listed in the store.
 
 ## FAQs — Teams apps and partner accounts
 


### PR DESCRIPTION
Added a guidance for GCC apps way forward.
"To make your app available for GCC users the auth process should identify and route the user to the right content URL as opposed to having duplicate apps listed in the store."