### PR TITLE
Update add-authentication to detail AAD V2

### DIFF
--- a/msteams-platform/bots/how-to/authentication/add-authentication.md
+++ b/msteams-platform/bots/how-to/authentication/add-authentication.md
@@ -120,6 +120,10 @@ In this procedure you'll use an Azure AD provider; other Azure AD supported iden
 
 ### Configure the identity provider connection and register it with the bot
 
+Note-there are two options for Service Providers here-Azure AD V1 and Azure AD V2.  The differences between the two providers are summarized [here](https://docs.microsoft.com/en-us/azure/active-directory/azuread-dev/azure-ad-endpoint-comparison), but in general, V2 provides more flexibility with respect to changing bot permissions.  Graph API permissions are listed in the scopes field, and as new ones are added, bots will allow users to consent to the new permissions on the next sign in.  For V1, the bot consent must be deleted by the user for new permissions to be prompted in the OAuth dialog. 
+
+#### Azure AD V1
+
 1. In the [**Azure portal**][azure-portal], select your resource group from the dashboard.
 1. Select your bot channel registration link.
 1. On the resource page, select **Settings**.
@@ -142,6 +146,29 @@ In this procedure you'll use an Azure AD provider; other Azure AD supported iden
     i. Leave **Scopes** blank. The following image is an example:
 
     ![teams bots app auth connection string adv1](../../../assets/images/authentication/auth-bot-identity-connection-adv1.png)
+
+1. Select **Save**.
+
+#### Azure AD V2
+
+1. In the [**Azure portal**][azure-portal], select your resource group from the dashboard.
+1. Select your bot channel registration link.
+1. On the resource page, select **Settings**.
+1. Under **OAuth Connection Settings** near the bottom of the page, select **Add Setting**.
+1. Complete the form as follows:
+
+    1. **Name**. Enter a name for the connection. You'll use this name in your bot in the `appsettings.json` file. For example *BotTeamsAuthADv2*.
+    1. **Service Provider**. Select **Azure Active Directory v2**. Once you select this, the Azure AD-specific fields will be displayed.
+    1. **Client id**. Enter the Application (client) ID that you recorded for your Azure identity provider app in the steps above.
+    1. **Client secret**. Enter the secret that you recorded for your Azure identity provider app in the steps above.
+    1. **Token Exchange URL**. Leave this blank.
+    1. **Tenant ID**, enter the **Directory (tenant) ID** that you recorded earlier for your Azure identity app or **common** depending on the supported account type selected when you created the identity provider app. To decide which value to assign follow these criteria:
+
+        - If you selected either *Accounts in this organizational directory only (Microsoft only - Single tenant)* or *Accounts in any organizational directory(Microsoft AAD directory - Multi tenant)* enter the **tenant ID** you recorded earlier for the AAD app. This will be the tenant associated with the users who can be authenticated.
+
+        - If you selected *Accounts in any organizational directory (Any AAD directory - Multi tenant and personal Microsoft accounts e.g. Skype, Xbox, Outlook)* enter the word **common** instead of a tenant ID. Otherwise, the AAD app will verify through the tenant whose ID was selected and exclude personal Microsoft accounts.
+
+    1. For **Scopes**, enter a space-delimited list of graph permissions this application requires e.g.: User.Read User.ReadBasic.All Mail.Read 
 
 1. Select **Save**.
 
@@ -379,6 +406,7 @@ This launches ngrok to listen on the port you specify. In return, it gives you a
 
 > [!NOTE]
 > If you stop and restart ngrok, the URL changes. To use ngrok in your project, and depending on the capabilities you're using, you must update all URL references.
+ 
 
 ## Additional information
 


### PR DESCRIPTION
This page should be brought in line with https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=aadv2%2Ccsharp to allow AAD V2.  I added the steps to configure the v2 provider.  I also added a comment about defining scopes, since this is the problem I moved to V2 to solve.  Feel free to revise, but I thought I'd point out that the docs were out of sync.  I've tested this with the OAuthDialog, and it works as expected.