### PR TITLE
Update graph-proactive-bots-and-messages.md

### DIFF
--- a/msteams-platform/graph-api/proactive-bots-and-messages/graph-proactive-bots-and-messages.md
+++ b/msteams-platform/graph-api/proactive-bots-and-messages/graph-proactive-bots-and-messages.md
@@ -99,7 +99,7 @@ The request will return a `teamsApp`  object. The returned object's `id`  is the
 **HTTP GET** request:
 
 ```http
-GET https://graph.microsoft.com/beta/users/{user-id}/teamwork/installedApps?$expand=teamsApp&$filter=teamsApp/id eq '{teamsAppId}'
+GET https://graph.microsoft.com/beta/users/{user-id}/teamwork/installedApps?$expand=teamsApp&$filter=teamsApp/externalId eq '{IdFromManifest}'
 ```
 
 **3.** If your app has already been uploaded/sideloaded for a channel in the team scope, you can retrieve the `teamsAppId` as follows:
@@ -109,7 +109,7 @@ GET https://graph.microsoft.com/beta/users/{user-id}/teamwork/installedApps?$exp
 **HTTP GET** request:
 
 ```http
-GET https://graph.microsoft.com/beta/teams/{team-id}/installedApps?$expand=teamsApp&$filter=teamsApp/externalId eq '{manifestId}'
+GET https://graph.microsoft.com/beta/teams/{team-id}/installedApps?$expand=teamsApp&$filter=teamsApp/externalId eq '{IdFromManifest}'
 ```
 
 >[!TIP]


### PR DESCRIPTION
- To retrieve the app information based on the IdFromManifest, the query must filter by the externalId property
- Replaced manifestId with IdFromManifest in order to make value consistent throw all examples