### PR TITLE
Fix an error in Teams Creation JSON (missing ',')

### DIFF
--- a/msteams-platform/graph-api/import-messages/import-external-messages-to-teams.md
+++ b/msteams-platform/graph-api/import-messages/import-external-messages-to-teams.md
@@ -65,7 +65,7 @@ Content-Type: application/json
   "@microsoft.graph.teamCreationMode": "migration",
   "template@odata.bind": "https://graph.microsoft.com/beta/teamsTemplates('standard')",
   "displayName": "My Sample Team",
-  "description": "My Sample Team’s Description"
+  "description": "My Sample Team’s Description",
   "createdDateTime": "2020-03-14T11:22:17.067Z"
 }
 ```


### PR DESCRIPTION
The sample JSON in step 1 - Create Team in migration mode - is missing a comma, leading to non valid JSON.