### PR TITLE
Update C# example to match scenario

### DIFF
--- a/msteams-platform/bots/how-to/conversations/conversation-basics.md
+++ b/msteams-platform/bots/how-to/conversations/conversation-basics.md
@@ -122,7 +122,7 @@ To send a text message, specify the string you want to send as the activity. In 
 # [C#/.NET](#tab/dotnet)
 
 ```csharp
-protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
 {
   await turnContext.SendActivityAsync(MessageFactory.Text($"Hello and welcome!"), cancellationToken);
 }


### PR DESCRIPTION
The C# example is using the wrong event handler for the part:

"The code below shows an example of sending a message when someone is added to a conversation" on l.120

I modified the example to use
```cs
OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
```