### PR TITLE
Personal apps mobile ga vikram

### DIFF
--- a/msteams-platform/tabs/design/tabs-mobile.md
+++ b/msteams-platform/tabs/design/tabs-mobile.md
@@ -6,7 +6,7 @@ keywords: teams design guidelines reference framework personal apps mobile tabs
 # Tabs on mobile
 
 > [!NOTE]
-> If you choose to have your channel/group tab appear on Teams mobile clients, the `setSettings()` configuration must have a value for the `websiteUrl` property (see below). Personal tabs are currently available in [developer preview](~/resources/dev-preview/developer-preview-intro.md). Full support for tabs on mobile clients will be released soon. To prepare for the update, you should follow the presented here when creating your tabs.
+> If you choose to have your channel/group tab appear on Teams mobile clients, the `setSettings()` configuration must have a value for the `websiteUrl` property (see below).
 
 Custom tabs can be part of a channel, group chat, or personal app (apps that contain static tabs and/or a one-to-one bot).
 

--- a/msteams-platform/tabs/design/tabs-mobile.md
+++ b/msteams-platform/tabs/design/tabs-mobile.md
@@ -86,7 +86,7 @@ Using our approved neutral palette for backgrounds, notifications, text, and but
 
 The way buttons are styled helps communicate what kind of action they trigger. We maintain a wide range of buttons that are formatted to show different levels of emphasis. Buttons can have text, an icon, or a combination of text and an icon. To communicate different levels in a hierarchy, we designed primary and secondary buttons within each category.
 
-![buttons](~/assets/images/buttons.png)
+![buttons image](~/assets/images/buttons.png)
 
 ![selection controls](~/assets/images/selection-controls.png)
 

--- a/msteams-platform/tabs/design/tabs.md
+++ b/msteams-platform/tabs/design/tabs.md
@@ -10,13 +10,6 @@ keywords: teams design guidelines reference framework tabs configuration
 >
 > Follow the [guidance for tabs on mobile](./tabs-mobile.md) when creating your tabs. If your tab uses authentication, you must upgrade your Teams JavaScript SDK to version 1.4.1 or later, or authentication will fail.
 >
-> **Personal (static) tabs on mobile:**
->
-> * Static tabs (personal app) are available in [developer preview](~/resources/dev-preview/developer-preview-intro.md).
-> * While building your static tabs, ensure to follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md)
->
-> **Channel/group (configurable) tabs on mobile:**
->
 > * Mobile clients only show tabs that have a value for `websiteUrl`. If you want your tab to appear on the Teams mobile clients, you must set the value of `websiteUrl`.
 > * Default open behavior on mobile is to open outside in browser using the `websiteUrl`. For apps published to the public App Store, if you want your channel tab to open inside teams by default, follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md), and reach out to your support rep to request to be whitelisted.
 

--- a/msteams-platform/tabs/design/tabs.md
+++ b/msteams-platform/tabs/design/tabs.md
@@ -92,7 +92,7 @@ Incorporating your own colors and layouts twill also aid in communicating person
 
 The dimensions of the tab configuration page:
 
-<img width="450px" title="Sizes for configuration tabs" src="~/assets/images/tabs/config-dialog-Contoso2.png" />
+<img width="450px" title="Sizes for configuration tabs" src="~/assets/images/tabs/config-dialog-Contoso2.png" alt="sizes for config tabs" />
 
 ### Guidelines for tab configuration page format
 
@@ -106,7 +106,7 @@ The dimensions of the tab configuration page:
 
 When properly sized, your tab configuration page should look similar to this:
 
-<img width="450px" title="New configuration tab" src="~/assets/images/tabs/config-dialog-Contoso.png" />
+<img width="450px" title="New configuration tab" src="~/assets/images/tabs/config-dialog-Contoso.png" alt="new config tab"/>
 
 ## Best practices
 
@@ -128,7 +128,7 @@ There are two modes of notification for tab content changes:
 
 > [!div class="checklist"]
 >
-> * **Use the app api to notify users of changes**. This message will show up in the user’s activity feed and deep link to the tab. *See*  [Create deep links to content and features in Microsoft Teams](../../concepts/build-and-test/deep-links.md?view=msteams-client-js-latest)
+> * **Use the app api to notify users of changes**. This message will show up in the user’s activity feed and deep link to the tab. *See*  [Create deep links to content and features in Microsoft Teams](../../concepts/build-and-test/deep-links.md?view=msteams-client-js-latest&preserve-view=true )
 > * **Use a bot**. This method is preferred especially if the Tab thread is targeted. The result will be that the tab’s threaded conversation will be moved into view as recently active. This method also allows for some sophistication in how the notification is sent.
 
   Sending a message to a tab thread increases the awareness of activity to all users without explicitly notifying everyone. This is awareness without noise. In addition, when you `@mention`  specific users the same notification will be placed in their feed, deep linking them to the tab thread directly.

--- a/msteams-platform/tabs/design/tabs.md
+++ b/msteams-platform/tabs/design/tabs.md
@@ -10,8 +10,8 @@ keywords: teams design guidelines reference framework tabs configuration
 >
 > Follow the [guidance for tabs on mobile](./tabs-mobile.md) when creating your tabs. If your tab uses authentication, you must upgrade your Teams JavaScript SDK to version 1.4.1 or later, or authentication will fail.
 >
- **Channel/group (configurable) tabs on mobile:**
-
+> **Channel/group (configurable) tabs on mobile:**
+>
 > * Mobile clients only show configurable tabs that have a value for `websiteUrl`. If you want your tab to appear on the Teams mobile clients, you must set the value of `websiteUrl`.
 > * Default open behavior on mobile is to open outside in browser using the `websiteUrl`. For apps published to the public App Store, if you want your channel tab to open inside teams by default, follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md), and reach out to your support rep to request to be whitelisted.
 

--- a/msteams-platform/tabs/design/tabs.md
+++ b/msteams-platform/tabs/design/tabs.md
@@ -10,7 +10,9 @@ keywords: teams design guidelines reference framework tabs configuration
 >
 > Follow the [guidance for tabs on mobile](./tabs-mobile.md) when creating your tabs. If your tab uses authentication, you must upgrade your Teams JavaScript SDK to version 1.4.1 or later, or authentication will fail.
 >
-> * Mobile clients only show tabs that have a value for `websiteUrl`. If you want your tab to appear on the Teams mobile clients, you must set the value of `websiteUrl`.
+ **Channel/group (configurable) tabs on mobile:**
+
+> * Mobile clients only show configurable tabs that have a value for `websiteUrl`. If you want your tab to appear on the Teams mobile clients, you must set the value of `websiteUrl`.
 > * Default open behavior on mobile is to open outside in browser using the `websiteUrl`. For apps published to the public App Store, if you want your channel tab to open inside teams by default, follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md), and reach out to your support rep to request to be whitelisted.
 
 Tabs are canvases that you can use to share content, hold conversations, and host third-party services, all within a team’s organic workflow. When you build a tab in Microsoft Teams, it puts your web app front and center where it’s easily accessible from key conversations.

--- a/msteams-platform/tabs/what-are-tabs.md
+++ b/msteams-platform/tabs/what-are-tabs.md
@@ -1,7 +1,7 @@
 ---
-title: What are custom tabs in Microsoft Teams?
+title: What are custom tabs in Teams?
 author: laujan
-description: An overview of custom tabs on the Microsoft Teams platform
+description: An overview of custom tabs on the Teams platform
 ms.topic: overview
 ms.author: lajanuar
 ---

--- a/msteams-platform/tabs/what-are-tabs.md
+++ b/msteams-platform/tabs/what-are-tabs.md
@@ -49,4 +49,4 @@ You can have a maximum of one (1) channel/group tab and up to sixteen (16) perso
 
 ## Mobile clients
 
-If you choose to have your channel/group tab appear on Teams mobile clients, the `setSettings()` configuration must have a value for the `websiteUrl` property. Personal tabs are currently available in [developer preview](~/resources/dev-preview/developer-preview-intro.md). Full support for tabs on mobile clients will be released soon. To prepare for the update, you should follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md) when creating your tabs.
+If you choose to have your channel/group tab/personal tab appear on Teams mobile clients, the `setSettings()` configuration must have a value for the `websiteUrl` property. To ensure optimal user experience, you should follow the [guidance for tabs on mobile](~/tabs/design/tabs-mobile.md) when creating your tabs.


### PR DESCRIPTION
Changes related to removing Dev preview references for Personal Apps on Mobile since they came out of Dev Preview and went live in May this year for both Android and iOS