### PR TITLE
Update teams-apps-in-meetings.md

### DIFF
--- a/msteams-platform/apps-in-teams-meetings/teams-apps-in-meetings.md
+++ b/msteams-platform/apps-in-teams-meetings/teams-apps-in-meetings.md
@@ -123,4 +123,4 @@ You can access the  **Meeting options** page as follows:
 ## Next Steps
 
 > [!div class="nextstepaction"]
-> [Enable apps in Teams meetings](apps-in-teams-meetings/enable-apps-in-meetings.md
+> [Enable apps in Teams meetings](apps-in-teams-meetings/enable-apps-in-meetings.md)


### PR DESCRIPTION
Fixed broken link under next steps. However, it looks like the "Enable apps in Teams meetings" documentation hasn't been published yet.