### PR TITLE
Added a note that the loading indicator is not supported on mobile

### DIFF
--- a/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
+++ b/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
@@ -65,7 +65,7 @@ Ensure that the all URL domains used in your tabs are included in the `validDoma
 Starting with [manifest schema v1.7](../../../resources/schema/manifest-schema.md), you can provide a [native loading indicator](../../../resources/schema/manifest-schema.md#showloadingindicator) wherever your web content is loaded in Teams, e.g., [tab content page](#integrate-your-code-with-teams), [configuration page](configuration-page.md), [removal page](removal-page.md) and [task modules in tabs](../../../task-modules-and-cards/task-modules/task-modules-tabs.md).
 
 > [!NOTE]
-> 1. Mobile does not yet support the loading indicator.
+> 1. The native loading indicator is not yet supported on mobile devices.
 > 2. If you indicate  `"showLoadingIndicator : true`  in your app manifest, then all tab configuration, content, and removal pages and all iframe-based task modules must follow the mandatory protocol, below:
 
 

--- a/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
+++ b/msteams-platform/tabs/how-to/create-tab-pages/content-page.md
@@ -65,7 +65,9 @@ Ensure that the all URL domains used in your tabs are included in the `validDoma
 Starting with [manifest schema v1.7](../../../resources/schema/manifest-schema.md), you can provide a [native loading indicator](../../../resources/schema/manifest-schema.md#showloadingindicator) wherever your web content is loaded in Teams, e.g., [tab content page](#integrate-your-code-with-teams), [configuration page](configuration-page.md), [removal page](removal-page.md) and [task modules in tabs](../../../task-modules-and-cards/task-modules/task-modules-tabs.md).
 
 > [!NOTE]
-> If you indicate  `"showLoadingIndicator : true`  in your app manifest, then all tab configuration, content, and removal pages and all iframe-based task modules must follow the mandatory protocol, below:
+> 1. Mobile does not yet support the loading indicator.
+> 2. If you indicate  `"showLoadingIndicator : true`  in your app manifest, then all tab configuration, content, and removal pages and all iframe-based task modules must follow the mandatory protocol, below:
+
 
 1. To show the loading indicator, add `"showLoadingIndicator": true` to your manifest. 
 2. Remember to call `microsoftTeams.initialize();`.


### PR DESCRIPTION
The native loading indicator is not yet supported on mobile. I wanted to call that out in the documentation.