### PR TITLE
[Webhook-connectors][correction][1437288]

### DIFF
--- a/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
@@ -61,7 +61,14 @@ You can also use this JSON to create cards containing rich inputs, such as text 
             "@type": "HttpPOST",
             "name": "Save",
             "target": "http://..."
-        }]
+        },
+        {
+      "@type": "OpenUri",
+      "name": "Learn More",
+      "targets": [
+        { "os": "default", "uri": "https://docs.microsoft.com/outlook/actionable-messages" }
+      ]
+    }]
     }, {
         "@type": "ActionCard",
         "name": "Change status",
@@ -103,8 +110,6 @@ Connector cards support three types of actions:
 - `ActionCard` Presents one or more input types and associated actions
 - `HttpPOST` Sends a POST request to a URL
 - `OpenUri` Opens a URI in a separate browser or app; optionally targets different URIs based on operating systems
-
-(A fourth action, `ViewAction`, is still supported but no longer needed; use `OpenUri` instead.)
 
 The `ActionCard` action supports three input types:
 

--- a/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
@@ -66,7 +66,6 @@ You can also use this JSON to create cards containing rich inputs, such as text 
             "@type": "OpenUri",
             "name": "Learn More",
             "targets": [{ "os": "default", "uri": "https://docs.microsoft.com/outlook/actionable-messages" }]
-      
         }
     }, {
         "@type": "ActionCard",

--- a/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
@@ -61,14 +61,13 @@ You can also use this JSON to create cards containing rich inputs, such as text 
             "@type": "HttpPOST",
             "name": "Save",
             "target": "http://..."
-        },
+        }]
         {
-      "@type": "OpenUri",
-      "name": "Learn More",
-      "targets": [
-        { "os": "default", "uri": "https://docs.microsoft.com/outlook/actionable-messages" }
-      ]
-    }]
+            "@type": "OpenUri",
+            "name": "Learn More",
+            "targets": [{ "os": "default", "uri": "https://docs.microsoft.com/outlook/actionable-messages" }]
+      
+        }
     }, {
         "@type": "ActionCard",
         "name": "Change status",


### PR DESCRIPTION
Removed (A fourth action, `ViewAction`, is still supported but no longer needed; use `OpenUri` instead.) from content. Added updated Json example.