### PR TITLE
Add missing square bracket

### DIFF
--- a/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
@@ -246,7 +246,7 @@ The following manifest.json file contains the basic elements needed to test and 
             "body":[
                 {
                 "type": "TextBlock",
-                "text": "For Samples and Templates, see https://adaptivecards.io/samples](https://adaptivecards.io/samples)",
+                "text": "For Samples and Templates, see [https://adaptivecards.io/samples](https://adaptivecards.io/samples)",
                 }
             ]
          }


### PR DESCRIPTION
[The example](https://github.com/MicrosoftDocs/msteams-docs/blob/master/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md#send-adaptive-cards-using-an-incoming-webhook) with markdown style for sending adaptive cards via an incoming webhook has no matching square brackets.