### PR TITLE
Fix JSON example of connector message

### DIFF
--- a/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
@@ -62,11 +62,13 @@ You can also use this JSON to create cards containing rich inputs, such as text 
             "name": "Save",
             "target": "http://..."
         }]
-        {
-            "@type": "OpenUri",
-            "name": "Learn More",
-            "targets": [{ "os": "default", "uri": "https://docs.microsoft.com/outlook/actionable-messages" }]
-        }
+    }, {
+        "@type": "OpenUri",
+        "name": "Learn More",
+        "targets": [{
+            "os": "default",
+            "uri": "https://docs.microsoft.com/outlook/actionable-messages"
+        }]
     }, {
         "@type": "ActionCard",
         "name": "Change status",


### PR DESCRIPTION
Fix the JSON example which has an invalid syntax in line no.65-69.
I consider that it is caused by the update in #2583 

I have tested my fix with Curl just in case.