### PR TITLE
Fix the example in sending adaptive cards

### DIFF
--- a/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/connectors-using.md
@@ -249,7 +249,7 @@ The following manifest.json file contains the basic elements needed to test and 
             "body":[
                 {
                 "type": "TextBlock",
-                "text": "For Samples and Templates, see [https://adaptivecards.io/samples](https://adaptivecards.io/samples)",
+                "text": "For Samples and Templates, see [https://adaptivecards.io/samples](https://adaptivecards.io/samples)"
                 }
             ]
          }


### PR DESCRIPTION
Fix example in line no.252.
Delete unnecessary comma in JSON example.

This is a missing correction in #2596 

Thanks in advance.