### PR TITLE
Update the wording in the top to clarify intent

### DIFF
--- a/msteams-platform/TOC.yml
+++ b/msteams-platform/TOC.yml
@@ -54,7 +54,7 @@
       href: bots/how-to/add-power-virtual-agents-bot-to-teams.md
     - name: Create a Virtual Assistant
       href: samples/virtual-assistant.md 
-  - name: Production-ready app templates
+  - name: App templates for Microsoft Teams
     href: samples/app-templates.md
   - name: Production-ready Shifts Connectors
     href: samples/shifts-wfm-connectors.md

--- a/msteams-platform/TOC.yml
+++ b/msteams-platform/TOC.yml
@@ -54,7 +54,7 @@
       href: bots/how-to/add-power-virtual-agents-bot-to-teams.md
     - name: Create a Virtual Assistant
       href: samples/virtual-assistant.md 
-  - name: App templates for Microsoft Teams
+  - name: App Templates for Microsoft Teams
     href: samples/app-templates.md
   - name: Production-ready Shifts Connectors
     href: samples/shifts-wfm-connectors.md

--- a/msteams-platform/TOC.yml
+++ b/msteams-platform/TOC.yml
@@ -54,7 +54,7 @@
       href: bots/how-to/add-power-virtual-agents-bot-to-teams.md
     - name: Create a Virtual Assistant
       href: samples/virtual-assistant.md 
-  - name: App Templates for Microsoft Teams
+  - name: App templates for Microsoft Teams
     href: samples/app-templates.md
   - name: Production-ready Shifts Connectors
     href: samples/shifts-wfm-connectors.md

--- a/msteams-platform/samples/app-templates.md
+++ b/msteams-platform/samples/app-templates.md
@@ -18,10 +18,10 @@ You, not Microsoft must license and support apps created from app templates for 
 
 ### Key benefits
 
-* **Deploy directly to the cloud:** All app templates include deployments scripts that will allow you to host all necessary services in Microsoft Azure or the Power Platform. 
-* **Recommended sample code:** The app templates conform to recommended best practices around security and infrastructure, and all community submitted changes to them are reviewed to ensure conformance.
+* **Deploy directly to the cloud:** All app templates include deployment scripts that allows you to host all required services in Microsoft Azure or the Power Platform. 
+* **Recommended sample code:** The app templates conform to recommended best practices around security and infrastructure. All community submitted changes to the app templates are reviewed to ensure conformance.
 * **Customizable and extensible:** While all app templates can be deployed with minimal configuration, we provide the entire code base and deployment scripts so that you can easily customize or extend them to fit your unique needs.
-* **Detailed documentation:** All app templates are accompanied by end-to-end documentation on solution architecture, deployment, and configuration steps. 
+* **Detailed documentation:** All app templates are accompanied by end-to-end documentation on solution architecture, deployment, and configuration steps.  
 
 ## Adoption Bot &#9734;
 

--- a/msteams-platform/samples/app-templates.md
+++ b/msteams-platform/samples/app-templates.md
@@ -11,8 +11,8 @@ author: laujan
 
 App templates are examples of complete apps for Microsoft Teams that are open-source and available on GitHub. Each app template contains detailed instructions for deploying and installing that app for your organization. It also provides a sample app that you can install and begin using immediately. The complete source code is available too, which allows you to explore it in detail or fork the code and alter it to meet your specific requirements.
 All app templates are provided under the [MIT License](https://github.com/OfficeDev/microsoft-teams-apps-eprescription/blob/master/LICENSE) terms.
-[!NOTE] 
-You, not Microsoft must license and support apps created from app templates for your users and organizations.
+>[!NOTE] 
+>You, not Microsoft must license and support apps created from app templates for your users and organizations.
 
 **&#9734; Indicates newly released app templates.**
 

--- a/msteams-platform/samples/app-templates.md
+++ b/msteams-platform/samples/app-templates.md
@@ -9,16 +9,17 @@ author: laujan
 
 # App Templates for Microsoft Teams
 
-App templates are production-ready apps for Microsoft Teams that are community driven, open-source, and available on GitHub. Each contains detailed instructions for deploying and installing that app for your organization, providing a ready-to-use app that you can install and begin using immediately. The complete source code is available as well, so you can explore it in detail, or fork the code and alter it to meet your specific needs.
+App templates are examples of complete apps for Microsoft Teams that are open-source, and available on GitHub. Each contains detailed instructions for deploying and installing that app for your organization, providing a sample app that you can install and begin using immediately. The complete source code is available as well, so you can explore it in detail, or fork the code and alter it to meet your specific needs.
+All app templates are provided under the [MIT License](https://github.com/OfficeDev/microsoft-teams-apps-eprescription/blob/master/LICENSE) terms. In addition, please note that  you, not Microsoft must license and support apps created from app templates for your users and organizations.
 
 **&#9734; Indicates newly released app templates.**
 
 ### Key benefits
 
-* **Plug and play experience:** All app templates include deployments scripts that will allow you to host all necessary services in Microsoft Azure. No coding is required to deploy the apps.
-* **Production-ready code:** The app templates conform to recommended best practices around security and infrastructure, and all community submitted changes to them are reviewed to ensure continued conformance.
-* **Customizable and extensible:** While all app templates are ready to deploy as they are, we provide the entire code base and deployment scripts so that you can easily customize or extend them to fit your unique needs.
-* **Detailed documentation & support:** All app templates are accompanied by end-to-end documentation on solution architecture, deployment, and configuration steps. The repositories are monitored as well, so please report any issues you encounter by raising an Issue on GitHub.
+* **Deploy directly to the cloud:** All app templates include deployments scripts that will allow you to host all necessary services in Microsoft Azure or the Power Platform. 
+* **Recommended sample code:** The app templates conform to recommended best practices around security and infrastructure, and all community submitted changes to them are reviewed to ensure conformance.
+* **Customizable and extensible:** While all app templates can be deployed with minimal configuration, we provide the entire code base and deployment scripts so that you can easily customize or extend them to fit your unique needs.
+* **Detailed documentation:** All app templates are accompanied by end-to-end documentation on solution architecture, deployment, and configuration steps. 
 
 ## Adoption Bot &#9734;
 

--- a/msteams-platform/samples/app-templates.md
+++ b/msteams-platform/samples/app-templates.md
@@ -9,8 +9,10 @@ author: laujan
 
 # App Templates for Microsoft Teams
 
-App templates are examples of complete apps for Microsoft Teams that are open-source, and available on GitHub. Each contains detailed instructions for deploying and installing that app for your organization, providing a sample app that you can install and begin using immediately. The complete source code is available as well, so you can explore it in detail, or fork the code and alter it to meet your specific needs.
-All app templates are provided under the [MIT License](https://github.com/OfficeDev/microsoft-teams-apps-eprescription/blob/master/LICENSE) terms. In addition, please note that  you, not Microsoft must license and support apps created from app templates for your users and organizations.
+App templates are examples of complete apps for Microsoft Teams that are open-source and available on GitHub. Each app template contains detailed instructions for deploying and installing that app for your organization. It also provides a sample app that you can install and begin using immediately. The complete source code is available too, which allows you to explore it in detail or fork the code and alter it to meet your specific requirements.
+All app templates are provided under the [MIT License](https://github.com/OfficeDev/microsoft-teams-apps-eprescription/blob/master/LICENSE) terms.
+[!NOTE] 
+You, not Microsoft must license and support apps created from app templates for your users and organizations.
 
 **&#9734; Indicates newly released app templates.**
 

--- a/msteams-platform/samples/app-templates.md
+++ b/msteams-platform/samples/app-templates.md
@@ -7,7 +7,7 @@ ms.author: lajanuar
 author: laujan
 ---
 
-# App Templates for Microsoft Teams
+# App templates for Microsoft Teams
 
 App templates are examples of complete apps for Microsoft Teams that are open-source and available on GitHub. Each app template contains detailed instructions for deploying and installing that app for your organization. It also provides a sample app that you can install and begin using immediately. The complete source code is available too, which allows you to explore it in detail or fork the code and alter it to meet your specific requirements.
 All app templates are provided under the [MIT License](https://github.com/OfficeDev/microsoft-teams-apps-eprescription/blob/master/LICENSE) terms.


### PR DESCRIPTION
Need to update the wording in the main catalog page to clarify intent and avoid confusion on the level of support for app templates.