### PR TITLE
Update detail-page-checklist.md

### DIFF
--- a/msteams-platform/concepts/deploy-and-publish/appsource/prepare/detail-page-checklist.md
+++ b/msteams-platform/concepts/deploy-and-publish/appsource/prepare/detail-page-checklist.md
@@ -150,7 +150,7 @@ Here's a view in [App Studio](https://aka.ms/InstallTeamsAppStudio):
 <br>`1.third`<br>
 >**[Unordered List](https://www.markdownguide.org/basic-syntax/#unordered-lists)**<br>
 ` - short` <br>`- bulleted` <br>`- list`<br>
->**Newline**. `Place <br> at the end of a line.` <br> 
+>**Newline**. Use a `\n` character to designate a newline.
  >**Escape.** Use an inline backslash to escape special characters. `\*asterisk`.
 
 **Example in Markdown format**


### PR DESCRIPTION
We have found that manifest parsing does not respect the `<br>` tags as the documentation describes, and including them will instead cause those tags to show up in a parsed manifest within Teams. Updating this line to prevent other developers from stepping in the same.

![image (8)](https://user-images.githubusercontent.com/3855429/113879123-72ed7880-9777-11eb-940c-dde30d3eba7a.png)
