### PR TITLE
Removed comma from applicationPermissions section

### DIFF
--- a/msteams-platform/resources/schema/manifest-schema.md
+++ b/msteams-platform/resources/schema/manifest-schema.md
@@ -255,7 +255,7 @@ The following schema sample shows all extensibility options:
       "Owner.Read.Group",
       "Member.ReadWrite.Group",
       "Owner.ReadWrite.Group"
-    ],
+    ]
   },
   "showLoadingIndicator": false,
   "isFullScreen": false,


### PR DESCRIPTION
Removed the comma in applicationPermissions section(line number: 258.)

Previous:
 "webApplicationInfo": {
    "id": "AAD App ID",
    "resource": "Resource URL for acquiring auth token for SSO",
    "applicationPermissions": [
      "Member.ReadWrite.Group",
      "Owner.ReadWrite.Group",
      .....
    ],
},



Updated:
Previous:
 "webApplicationInfo": {
    "id": "AAD App ID",
    "resource": "Resource URL for acquiring auth token for SSO",
    "applicationPermissions": [
      "Member.ReadWrite.Group",
      "Owner.ReadWrite.Group",
      .....
    ]
},