### PR TITLE
typo: "Teams Toolkit for Visual Stuido Code" fixed

### DIFF
--- a/msteams-platform/tabs/what-are-tabs.md
+++ b/msteams-platform/tabs/what-are-tabs.md
@@ -76,7 +76,7 @@ For channel or group tabs, you can also create an additional configuration page.
 You can have multiple channels or group tabs, and up to 16 personal tabs per app.
 
 ### Tools you can use to build tabs
-* [Teams Toolkit for Visual Stuido Code](../toolkit/visual-studio-code-overview.md)
+* [Teams Toolkit for Visual Studio Code](../toolkit/visual-studio-code-overview.md)
 * [Teams Toolkit for Visual Stuido](../toolkit/visual-studio-overview.md)
 
 ## See also


### PR DESCRIPTION
typo fixed "Teams Toolkit for Visual Stuido Code"  to "Teams Toolkit for Visual Studio Code"