### PR TITLE
Update guideline for WebApplicationInfo.Id

### DIFF
--- a/msteams-platform/bots/how-to/authentication/auth-aad-sso-bots.md
+++ b/msteams-platform/bots/how-to/authentication/auth-aad-sso-bots.md
@@ -140,7 +140,7 @@ If the application contains a bot and a tab, then use the following code to add 
 
 **webApplicationInfo** is the parent of the following elements:
 
-* **id** - The client ID of the application. This is the application ID that you obtained as part of registering the application with AAD.
+* **id** - The client ID of the application. This is the application ID that you obtained as part of registering the application with AAD. It is recommended that this Application ID not be shared between multiple Teams apps and a new AAD app be created for each application manifest that uses `webApplicationInfo`.
 * **resource** - The domain and subdomain of your application. This is the same URI, including the `api://` protocol that you registered when creating your `scope` in [Register your app through the AAD portal](#register-your-app-through-the-aad-portal). You must not include the `access_as_user` path in your resource. The domain part of this URI must match the domain and subdomains used in the URLs of your Teams application manifest.
 
 ### Add the code to request and receive a bot token


### PR DESCRIPTION
As a principle, AAD app IDs should not be shared between multiple apps/app manifest. 
This update provides the recommendation for the same.