### PR TITLE
Update the scope of GetMeetingParticipant API

### DIFF
--- a/msteams-platform/apps-in-teams-meetings/create-apps-for-teams-meetings.md
+++ b/msteams-platform/apps-in-teams-meetings/create-apps-for-teams-meetings.md
@@ -68,7 +68,7 @@ To identify and retrieve contextual information for your tab content, see [get c
 > * Do not cache participant roles since the meeting organizer can change the roles any time.
 > * Teams does not currently support large distribution lists or roster sizes of more than 350 participants for the `GetParticipant` API.
 
-The `GetParticipant` API allows a bot to fetch participant information by meeting ID and participant ID. The API includes query parameters, examples, and response codes.
+The `GetParticipant` API allows a bot to fetch participant information by meeting ID and participant ID. The API includes query parameters, examples, and response codes. Now the API is supported in both private scheduled/recurring meeting and channel scheduled/recurring meeting. 
 
 #### Query parameters
 

--- a/msteams-platform/apps-in-teams-meetings/create-apps-for-teams-meetings.md
+++ b/msteams-platform/apps-in-teams-meetings/create-apps-for-teams-meetings.md
@@ -68,7 +68,7 @@ To identify and retrieve contextual information for your tab content, see [get c
 > * Do not cache participant roles since the meeting organizer can change the roles any time.
 > * Teams does not currently support large distribution lists or roster sizes of more than 350 participants for the `GetParticipant` API.
 
-The `GetParticipant` API allows a bot to fetch participant information by meeting ID and participant ID. The API includes query parameters, examples, and response codes. Now the API is supported in both private scheduled/recurring meeting and channel scheduled/recurring meeting. 
+The `GetParticipant` API allows a bot to fetch participant information by meeting ID and participant ID. The API includes query parameters, examples, and response codes. The API is supported in both private scheduled or recurring meeting and channel scheduled or recurring meeting. 
 
 #### Query parameters
 


### PR DESCRIPTION
As GetMeetingParticipant API is now supported both in private meeting and channel meeting, update the doc to inform users about this.