### PR TITLE
Device permissions in the browser for developers

### DIFF
--- a/msteams-platform/concepts/device-capabilities/browser-device-permissions.md
+++ b/msteams-platform/concepts/device-capabilities/browser-device-permissions.md
@@ -9,85 +9,28 @@ ms.topic: how-to
 # Device permissions for the browser
 
 > [!NOTE]
-> The device permissions for the browser feature is currently available in [public developer preview](../../resources/dev-preview/developer-preview-intro.md) only. 
-> This feature will be generally available (GA) by January 21, 2022.
+> The change to how device permissions are handled in the browser is currently available in [public developer preview](../../resources/dev-preview/developer-preview-intro.md) only. 
+> This change will be generally available (GA) by January 21, 2022.
 
-Users can grant permission for each app and consent to device permissions. Previously, browser level permissions were handled as top-level permission for Teams only. Consent for each app wasn't provided separately. At the browser level there are two levels of permissions:
+Applications that require device permissions - such as camera or microphone access - now require users to manually grant consent at a per app level in the web browser. Previously, the browser handled how these permissions were granted, but now these permissions will be handled in Microsoft Teams. This has implications on how you design your application if they require these permissions in the browser.
 
-* Teams overall permission for the browser.
-* Teams controlled individual permissions for each app.
+## Change in behavior
+If your application has declared that it needs device permissions in your [application manifest](native-device-permissions.md), then users will be shown an "app permissions" option where they can enable an app’s device permissions. The "app permissions" option can be found in personal apps, task module dialogs, and tabs in chats, channels or meetings.
 
-Device permission requests can't be intercepted from iframe. You can only allow or deny permissions before the iframe is loaded. The user must know which device permissions to enable before the tab loads to enhance their experience. If the user needs to change the permissions, they must reload the iframe. The following image demonstrates the device permissions flow for granting or denying access:
+### Personal apps and task module dialogs
+The "app permissions" setting can be found in the top-right.
+<img src="../../assets/images/tabs/apppermissions.png" alt="App permissions button" width="800"/>
 
-<img src="~/assets/images/tabs/devicepermissionsflowchart.png" alt="Device permissions flow access" width="600"/>
+### Chat, channel or meeting tabs
+The "app permissions" setting can be found in the tab dropdown.
+![App permissions drop-down](../../assets/images/tabs/drop-downapppermissions.png)
 
-## Scenario
+A user will need to enable these permissions in the browser for these permissions to take effect. Once a user changes an app’s device permissions in the browser, they will be prompted to reload the application in Teams. It is important that you make users aware of where to go in order to enable these permissions in Microsoft Teams.
 
-Sarah, a lawyer at Contoso Partners, uses OneNote from browser to take meeting notes in Teams. OneNote requires microphone access to record dictations. A dialog box appears prompting to grant access. Sarah only uses OneNote to take notes and decides to deny access.
+## Recommendation
+Microsoft Teams applications that require device permissions in the browser are expected to show instructions to users on where to find and enable these permissions in the Teams UI. Depending on the context in which your application is running, you will need to ensure your instructions are pointing the user to correct location to access these permissions as they differ for personal apps, task module dialogs, and tabs in chats, channels or meetings.
 
-A few months later, Sarah needs to record an important meeting and decides to use the dictation feature. But a dialog box appears, stating **We don't have access to your microphone. Please check that your browser has permission to use your microphone**:
-
-![Permissions not available](../../assets/images/tabs/permissionsnotavailable.png)
-
-Sarah then checks her app permissions or settings in Teams to grant OneNote access to her microphone.
-
-## Solutions
-
-The solutions for the security applications are as follows:
-
-* Introduce device permissions consent experience in the browser: All apps' permissions are managed individually instead of relying on the browser to provide support.
-* Allow users to manage their device permissions for each app in the browser: Previously, device permissions for embedded iframes were handled by the browser. With the recent change to Chromium, users can manage their device permissions for each Teams tab through **App permissions**, app dropdown list, or **Settings**.
-
-Users can have various apps in Teams and each require device permissions. For example, in OneNote the user must grant permissions for media, such as microphone. There's a property on iframe that allows the user to use different media for that app.
-
-**To grant access to app for device permissions using App permissions**
-
-> [!NOTE]  
-> To access camera or microphone, you must enable it. 
-
-1. In your browser, open [teams.microsoft.com](https://teams.microsoft.com/).
-1. Select the app, for example, OneNote that you want to use from the left bar.
-1. Select **App permissions** from the upper right corner.
-
-    <img src="../../assets/images/tabs/apppermissions.png" alt="App permissions button" width="800"/>
-
-1. Turn on **Media (Camera, microphone, speakers)** and close the dialog box.
-
-    <img src="../../assets/images/tabs/enable-access.png" alt="Enable camera access" width="800"/>
-
-           
-1. Select **Refresh now** to reload the page for new iframe permissions to take effect.       
-1. Check if the device permission is granted. For example, if you're using OneNote, you can select **Dictate** to record your notes.
-
-**To grant access to app for device permissions using the dropdown list for a team**
-
-1. In your browser, open [teams.microsoft.com](https://teams.microsoft.com/).
-1. Select **Teams** from the left pane.
-1. Select a team where you want to use an app.
-1. Add the app, for example, OneNote if it isn't already added.
-1. Select the dropdown list for **My Notebook** in this case and select **App permissions**.
-
-    ![App permissions drop-down](../../assets/images/tabs/drop-downapppermissions.png)
-
-1. Turn on **Media (Camera, microphone, speakers)** and close the dialog box.
-1. Select **Refresh now** to reload the page.
-1. Check if the device permission is granted. For example, if you're using OneNote, you can select **Dictate** to record your notes.
-
-**Optionally to grant access to app for device permissions using Settings**
-
-1. In your browser, open [teams.microsoft.com](https://teams.microsoft.com/).
-1. Select the app, for example, OneNote that you want to use from the left pane.
-1. If you're using OneNote, you can select **Dictate** to record your notes. A dialog box appears to state the permissions are denied.
-1. Select the icon for your user account from the upper right corner and select **Manage account**.
-1. From the **Settings** popup, select **App permissions**.
-
-    ![Settings for app permissions](../../assets/images/tabs/settingsapppermissions.png)
-
-1. Select the app where you want to grant access.
-1. Turn on **Media (Camera, microphone, speakers)**.
-1. In your browser, select **Refresh**. A dialog box appears asking you to reload the page.
-1. Select **Refresh now** to reload the page for new iframe permissions to take effect.
-1. Similarly, you can turn on other permissions, such as location or MIDI device as required to use the app.
+<img src="../../assets/images/tabs/enable-access.png" alt="Enable camera access" width="800"/>
 
 ## See also
 


### PR DESCRIPTION
I rewrote the documentation of the `1456520-devicepermissions` branch to be more developer focused with clearer recommendations for developers to follow.