### PR TITLE
Fix SaaS offer doc issues

### DIFF
--- a/msteams-platform/concepts/deploy-and-publish/appsource/prepare/include-saas-offer.md
+++ b/msteams-platform/concepts/deploy-and-publish/appsource/prepare/include-saas-offer.md
@@ -52,13 +52,13 @@ When planning how to monetize your Teams app, here are some things to consider:
 
 Integrating with the SaaS Fulfillment APIs is required for monetizing your Teams app. These APIs help you manage the lifecycle of a subscription plan once it’s purchased by a user.
 
-For complete instructions and API reference, see the [SaaS Fulfillment APIs documentation](/azure/marketplace/partner-center-portal/pc-saas-fulfillment-api-v2). In general, you’ll implement the following steps using the APIs once a subscription is purchased:
+For complete instructions and API reference, see the [SaaS Fulfillment APIs documentation](/azure/marketplace/partner-center-portal/pc-saas-fulfillment-apis). In general, you’ll implement the following steps using the APIs once a subscription is purchased:
 
-1.	Receive a [*purchase identification token*](/azure/marketplace/partner-center-portal/pc-saas-fulfillment-api-v2#purchased-but-not-yet-activated-pendingfulfillmentstart) via the URL to your landing page.
+1. Receive a [*purchase identification token*](/azure/marketplace/partner-center-portal/pc-saas-fulfillment-life-cycle#purchased-but-not-yet-activated-pendingfulfillmentstart) via the URL to your landing page.
 
-1.	Use the token to retrieve subscription details.
+1. Use the token to retrieve subscription details.
 
-1.	Notify the commercial marketplace that the subscription is activated.
+1. Notify the commercial marketplace that the subscription is activated.
 
 ### Best practices for implementing subscription management
 

--- a/msteams-platform/resources/schema/manifest-schema.md
+++ b/msteams-platform/resources/schema/manifest-schema.md
@@ -762,7 +762,7 @@ Specifies the SaaS offer associated with your app.
 |---|---|---|---|---|
 |`offerId`| string | 2,048 characters | ✔ | A unique identifier that includes your Publisher ID and Offer ID, which you can find in [Partner Center](https://partner.microsoft.com/dashboard). You must format the string as `publisherId.offerId`.|
 
-## See Also
+## See also
 
 * [Understand the Microsoft Teams app structure](~/concepts/design/app-structure.md)
 * [Enable app customization](~/concepts/design/enable-app-customization.md)

--- a/msteams-platform/resources/schema/manifest-schema.md
+++ b/msteams-platform/resources/schema/manifest-schema.md
@@ -293,7 +293,7 @@ The following schema sample shows all extensibility options:
     "team": "bot", 
     "groupchat": "bot"
   },
- "configurableProperties": {
+ "configurableProperties": [
      "name",
      "shortDescription",
      "longDescription",
@@ -303,6 +303,9 @@ The following schema sample shows all extensibility options:
      "developerUrl",
      "privacyUrl",
      "termsOfUseUrl"        
+ ],
+  "subscriptionOffer": {
+    "offerId": "publisherId.offerId"
   }
 }
 ```
@@ -741,7 +744,6 @@ You can define any of the following properties:
  
 When `defaultBlockUntilAdminAction` property is set to **true**, the app is hidden from users by default until admin allows it. If set to **true**, the app is hidden for all tenants and end users. The tenant admins can see the app in the Teams admin center and take action to allow or block the app. The default value is **false**. For more information on default app block, see [Hide Teams app until admin approves](~/concepts/design/enable-app-customization.md#hide-teams-app-until-admin-approves).
 
-
 ## publisherDocsUrl
 
 **Optional** - string
@@ -749,6 +751,16 @@ When `defaultBlockUntilAdminAction` property is set to **true**, the app is hidd
 **Maximum size** - 128 characters
 
 The property is dependant on `defaultBlockUntilAdminAction`. When `defaultBlockUntilAdminAction` property is set to **true**, the `publisherDocsUrl` provides HTTPS URL to an information page for admins to get guidelines before allowing an app, which is blocked by default.
+
+## subscriptionOffer
+
+**Optional** - object
+
+Specifies the SaaS offer associated with your app.
+
+|Name| Type| Maximum size | Required | Description|
+|---|---|---|---|---|
+|`offerId`| string | 2,048 characters | ✔ | A unique identifier that includes your Publisher ID and Offer ID, which you can find in [Partner Center](https://partner.microsoft.com/dashboard). You must format the string as `publisherId.offerId`.|
 
 ## See Also
 


### PR DESCRIPTION
Updated broken links and added the `subscriptionOffer` property to the public manifest schema (should have been there already).