### PR TITLE
Add missing tilde to webhook docs link.

### DIFF
--- a/msteams-platform/webhooks-and-connectors/how-to/add-incoming-webhook.md
+++ b/msteams-platform/webhooks-and-connectors/how-to/add-incoming-webhook.md
@@ -53,7 +53,7 @@ The following table provides the features and description of Incoming Webhook:
 
 The webhook is available in the Teams channel.
 
-You can create and send actionable messages through Incoming Webhook or Office 365 Connector. For more information, see [Create and send messages](/webhooks-and-connectors/how-to/connectors-using?tabs=cURL).
+You can create and send actionable messages through Incoming Webhook or Office 365 Connector. For more information, see [Create and send messages](~/webhooks-and-connectors/how-to/connectors-using.md).
 
 > [!NOTE]
 > In Teams, select **Settings** > **Member permissions** > **Allow members to create, update, and remove connectors**, so that any team member can add, modify, or delete a connector.


### PR DESCRIPTION
The missing tilde caused this link to be "dead", and giving a 404: https://docs.microsoft.com/en-us/webhooks-and-connectors/how-to/connectors-using?tabs=cURL