### PR TITLE
Add SSO section for M365 Apps messaging extensions tutorial

### DIFF
--- a/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
+++ b/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
@@ -86,6 +86,28 @@ For users to interact with your messaging extension from Outlook, you'll need to
 
     :::image type="content" source="images/azure-bot-channels.png" alt-text="Azure Bot Channels pane listing both Microsoft Teams and Outlook channels":::
 
+## Update Azure AD app registration for SSO
+
+> [!NOTE]
+> You can skip this step if you are using the [Teams messaging extension search sample](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/javascript_nodejs/50.teams-messaging-extensions-search), as the scenario doesn't involve Azure Active Directory (AAD) Single Sign-On authentication.
+
+Azure Active Directory Single-sign on (SSO) for messaging extensions works the same way in Outlook [as it does in Teams](/microsoftteams/platform/bots/how-to/authentication/auth-aad-sso-bots), however you will need to add several client application identifiers to the Azure AD app registration of your tab app in your tenant's *App registrations* portal.
+
+1. Sign in to [Azure portal](https://portal.azure.com) with your sandbox tenant account.
+1. Open the **App registrations** blade.
+1. Select the name of your application to open its app registration.
+1. Select  **Expose an API** (under *Manage*).
+
+In the **Authorized client applications** section, ensure all of the following `Client Id` values are listed:
+
+|Microsoft 365 client application | Client ID |
+|--|--|
+|Teams desktop, mobile |1fec8e78-bce4-4aaf-ab1b-5451cc387264 |
+|Teams web |5e3ce6c0-2b1f-4285-8d4b-75ee78787346 |
+|Outlook desktop | d3590ed6-52b3-4102-aeff-aad2292ab01c |
+|Outlook Web Access | 00000002-0000-0ff1-ce00-000000000000 |
+|Outlook Web Access | bc59ab01-8403-45c6-8796-ac3ef710b3e3 |
+
 ## Sideload your updated messaging extension in Teams
 
 The final step is to sideload your updated messaging extension ([app package](/microsoftteams/platform/concepts/build-and-test/apps-package)) in Microsoft Teams. Once completed, your messaging extension will appear in your installed *Apps* from the compose message area.

--- a/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
+++ b/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
@@ -89,12 +89,12 @@ For users to interact with your messaging extension from Outlook, you'll need to
 ## Update Azure AD app registration for SSO
 
 > [!NOTE]
-> You can skip this step if you are using the [Teams messaging extension search sample](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/javascript_nodejs/50.teams-messaging-extensions-search), as the scenario doesn't involve Azure Active Directory (AAD) Single Sign-On authentication.
+> You can skip the step if you're using [Teams messaging extension search sample](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/javascript_nodejs/50.teams-messaging-extensions-search), as the scenario doesn't involve Azure Active Directory (AAD) Single Sign-On authentication.
 
-Azure Active Directory Single-sign on (SSO) for messaging extensions works the same way in Outlook [as it does in Teams](/microsoftteams/platform/bots/how-to/authentication/auth-aad-sso-bots), however you will need to add several client application identifiers to the Azure AD app registration of your bot in your tenant's *App registrations* portal.
+Azure Active Directory Single-sign on (SSO) for messaging extensions works the same way in Outlook [as it does in Teams](/microsoftteams/platform/bots/how-to/authentication/auth-aad-sso-bots), however you need to add several client application identifiers to the Azure AD app registration of your bot in your tenant's *App registrations* portal.
 
 1. Sign in to [Azure portal](https://portal.azure.com) with your sandbox tenant account.
-1. Open the **App registrations** blade.
+1. Open **App registrations**.
 1. Select the name of your application to open its app registration.
 1. Select  **Expose an API** (under *Manage*).
 
@@ -102,7 +102,7 @@ In the **Authorized client applications** section, ensure all of the following `
 
 |Microsoft 365 client application | Client ID |
 |--|--|
-|Teams desktop, mobile |1fec8e78-bce4-4aaf-ab1b-5451cc387264 |
+|Teams desktop and mobile |1fec8e78-bce4-4aaf-ab1b-5451cc387264 |
 |Teams web |5e3ce6c0-2b1f-4285-8d4b-75ee78787346 |
 |Outlook desktop | d3590ed6-52b3-4102-aeff-aad2292ab01c |
 |Outlook Web Access | 00000002-0000-0ff1-ce00-000000000000 |

--- a/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
+++ b/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
@@ -91,7 +91,7 @@ For users to interact with your messaging extension from Outlook, you'll need to
 > [!NOTE]
 > You can skip this step if you are using the [Teams messaging extension search sample](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/javascript_nodejs/50.teams-messaging-extensions-search), as the scenario doesn't involve Azure Active Directory (AAD) Single Sign-On authentication.
 
-Azure Active Directory Single-sign on (SSO) for messaging extensions works the same way in Outlook [as it does in Teams](/microsoftteams/platform/bots/how-to/authentication/auth-aad-sso-bots), however you will need to add several client application identifiers to the Azure AD app registration of your tab app in your tenant's *App registrations* portal.
+Azure Active Directory Single-sign on (SSO) for messaging extensions works the same way in Outlook [as it does in Teams](/microsoftteams/platform/bots/how-to/authentication/auth-aad-sso-bots), however you will need to add several client application identifiers to the Azure AD app registration of your bot in your tenant's *App registrations* portal.
 
 1. Sign in to [Azure portal](https://portal.azure.com) with your sandbox tenant account.
 1. Open the **App registrations** blade.


### PR DESCRIPTION
Added guidance for enabling messaging extensions SSO now that it's supported in Outlook.