### PR TITLE
Adding Azure interoperability to overview page

### DIFF
--- a/msteams-platform/overview.md
+++ b/msteams-platform/overview.md
@@ -210,6 +210,14 @@ You can preview your Teams apps running in other high usage Microsoft 365 experi
 > [!div class="nextstepaction"]
 > [Extend your app](m365-apps/overview.md)
 
+
+## Integrate Teams in your external app
+This page focuses on embedding your own experiences into Microsoft Teams by building Teams apps. If you'd like to *reverse* this model and integrate Teams or other communication capabilities into your own external app experience, see [Azure Communication Services](/azure/communication-services/overview). Azure Communication Services are cloud-based services with REST APIs and client library SDKs to help you integrate communication into your own custom applications. You can embed generic or Teams-styled React Web components for calling and chat with the help of the [UI library](https://azure.github.io/communication-ui-library/).
+
+Azure Communication Services applications can use public preview functionality to [interoperate with Teams](/azure/communication-services/concepts/teams-interop) and enable your custom application to join Teams meetings anonymously. For example, you can integrate video calling into a mobile banking application and allow end-users to virtually meet with bank employees using Microsoft Teams. 
+
+You can also integrate Microsoft 365 identity to build external applications that embed video and PSTN calling on behalf of a Teams user. If you've used [Skype for Business SDKs](/skype-sdk/appsdk/skypeappsdk) in the past, these capabilities as part of Azure Communication Services are recommended as a replacement.
+
 ## See also
 
 * [App fundamentals](~/concepts/app-fundamentals-overview.md)


### PR DESCRIPTION
This change was already published.. as https://github.com/MicrosoftDocs/msteams-docs/pull/3858. However the change was accidently undone.