### PR TITLE
Removed note about deeplink to calls for mobile

### DIFF
--- a/msteams-platform/concepts/build-and-test/deep-links.md
+++ b/msteams-platform/concepts/build-and-test/deep-links.md
@@ -244,9 +244,6 @@ In case of a video call, the client will ask for confirmation and turn on the ca
 > [!NOTE]
 > This deeplink cannot be used for invoking a meeting.
 
-> [!NOTE]
-> Currently, deeplink to call is not supported on Teams mobile devices.
-
 ### Generate a deep link to a call
 
 | Deep link | Format | Example |


### PR DESCRIPTION
Per PM recommendation, there no longer is a restriction for mobile for deeplinking to calls.