### PR TITLE
Add missing onMessage call to get-teams-context.md

### DIFF
--- a/msteams-platform/bots/how-to/get-teams-context.md
+++ b/msteams-platform/bots/how-to/get-teams-context.md
@@ -53,7 +53,7 @@ export class MyBot extends TeamsActivityHandler {
             var members = [];
 
             do {
-                var pagedMembers = await TeamsInfo.getPagedMembers(context, 100, continuationToken);
+                var pagedMembers = await TeamsInfo.getPagedMembers(turnContext, 100, continuationToken);
                 continuationToken = pagedMembers.continuationToken;
                 members.push(...pagedMembers.members);
             }
@@ -147,7 +147,7 @@ export class MyBot extends TeamsActivityHandler {
 
         // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
         this.onMessage(async (turnContext, next) => {
-            const member = await TeamsInfo.getMember(context, encodeURI('someone@somecompany.com'));
+            const member = await TeamsInfo.getMember(turnContext, encodeURI('someone@somecompany.com'));
 
             // By calling next() you ensure that the next BotHandler is run.
             await next();

--- a/msteams-platform/bots/how-to/get-teams-context.md
+++ b/msteams-platform/bots/how-to/get-teams-context.md
@@ -146,10 +146,11 @@ export class MyBot extends TeamsActivityHandler {
         super();
 
         // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
-        const member = await TeamsInfo.getMember(context, encodeURI('someone@somecompany.com'));
+        this.onMessage(async (turnContext, next) => {
+            const member = await TeamsInfo.getMember(context, encodeURI('someone@somecompany.com'));
 
-        // By calling next() you ensure that the next BotHandler is run.
-        await next();
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
         });
     }
 }


### PR DESCRIPTION
1. All other TypeScript examples on this page call `this.onMessage` correctly. One example does not.
2. Some examples name their parameter `turnContext` but use `context` instead.