### PR TITLE
Update teams-developer-portal.md

### DIFF
--- a/msteams-platform/concepts/build-and-test/teams-developer-portal.md
+++ b/msteams-platform/concepts/build-and-test/teams-developer-portal.md
@@ -13,7 +13,8 @@ The <a href="https://dev.teams.microsoft.com" target="_blank">Developer Portal f
 
 :::image type="content" source="../../assets/images/tdp/tdp_home_1.png" alt-text="Screenshot showing the home page of the Developer Portal for Teams.":::
 
-> [!NOTE] The Developer Portal is not available for GCC, GCCH or DoD tenants.
+> [!NOTE] 
+> The Developer Portal is not available for Government Community Cloud (GCC), GCC-High or Department of Defense (DOD) tenants.
 
 ## Register an app
 

--- a/msteams-platform/concepts/build-and-test/teams-developer-portal.md
+++ b/msteams-platform/concepts/build-and-test/teams-developer-portal.md
@@ -14,7 +14,7 @@ The <a href="https://dev.teams.microsoft.com" target="_blank">Developer Portal f
 :::image type="content" source="../../assets/images/tdp/tdp_home_1.png" alt-text="Screenshot showing the home page of the Developer Portal for Teams.":::
 
 > [!NOTE] 
-> The Developer Portal is not available for Government Community Cloud (GCC), GCC-High or Department of Defense (DOD) tenants.
+> Currently, Developer Portal is not available for Government Community Cloud (GCC), GCC-High, or Department of Defense (DOD) tenants.
 
 ## Register an app
 

--- a/msteams-platform/concepts/build-and-test/teams-developer-portal.md
+++ b/msteams-platform/concepts/build-and-test/teams-developer-portal.md
@@ -13,6 +13,8 @@ The <a href="https://dev.teams.microsoft.com" target="_blank">Developer Portal f
 
 :::image type="content" source="../../assets/images/tdp/tdp_home_1.png" alt-text="Screenshot showing the home page of the Developer Portal for Teams.":::
 
+> [!NOTE] The Developer Portal is not available for GCC, GCCH or DoD tenants.
+
 ## Register an app
 
 The Developer Portal provides a couple ways to register a Teams app:


### PR DESCRIPTION
added note indicating that Teams developer portal is not available for gov clouds.