### PR TITLE
[Doc Improvement][Requirements for specific share to stage][2313586]

### DIFF
--- a/msteams-platform/apps-in-teams-meetings/enable-and-configure-your-app-for-teams-meetings.md
+++ b/msteams-platform/apps-in-teams-meetings/enable-and-configure-your-app-for-teams-meetings.md
@@ -180,7 +180,7 @@ Participants can share specific parts of the app to the collaborative meeting st
 To share specific parts of the app to stage, you must invoke the related APIs in the Teams client SDK library. For more information, see [API reference](API-references.md).
 
 > [!NOTE]
-> * To share specific parts of the app to stage, use Teams manifest version 1.12 or later
+> * To share specific parts of the app to stage, use Teams manifest version 1.12 or later.
 > * Share specific parts of the app to stage is supported for Teams desktop clients only.
 
 ### After a meeting

--- a/msteams-platform/apps-in-teams-meetings/enable-and-configure-your-app-for-teams-meetings.md
+++ b/msteams-platform/apps-in-teams-meetings/enable-and-configure-your-app-for-teams-meetings.md
@@ -179,6 +179,9 @@ Participants can share specific parts of the app to the collaborative meeting st
 
 To share specific parts of the app to stage, you must invoke the related APIs in the Teams client SDK library. For more information, see [API reference](API-references.md).
 
+> [!NOTE]
+> Teams manifest version 1.12 or higher is required to support sharing specific parts of the app to stage. Share specific parts of the app to stage is supported on Teams Desktop clients only.
+
 ### After a meeting
 
 The configurations of after and [before meetings](#before-a-meeting) are the same.

--- a/msteams-platform/apps-in-teams-meetings/enable-and-configure-your-app-for-teams-meetings.md
+++ b/msteams-platform/apps-in-teams-meetings/enable-and-configure-your-app-for-teams-meetings.md
@@ -180,7 +180,8 @@ Participants can share specific parts of the app to the collaborative meeting st
 To share specific parts of the app to stage, you must invoke the related APIs in the Teams client SDK library. For more information, see [API reference](API-references.md).
 
 > [!NOTE]
-> Teams manifest version 1.12 or higher is required to support sharing specific parts of the app to stage. Share specific parts of the app to stage is supported on Teams Desktop clients only.
+> * To share specific parts of the app to stage, use Teams manifest version 1.12 or later
+> * Share specific parts of the app to stage is supported for Teams desktop clients only.
 
 ### After a meeting
 


### PR DESCRIPTION
Added note explaining Teams manifest 1.12 or higher is required, and that web client does not support this functionality.