### PR TITLE
Remove old office.com appID from table

### DIFF
--- a/msteams-platform/m365-apps/extend-m365-teams-personal-tab.md
+++ b/msteams-platform/m365-apps/extend-m365-teams-personal-tab.md
@@ -134,7 +134,6 @@ In the **Authorized client applications** section, ensure all of the following `
 |--|--|
 |Teams desktop, mobile |1fec8e78-bce4-4aaf-ab1b-5451cc387264 |
 |Teams web |5e3ce6c0-2b1f-4285-8d4b-75ee78787346 |
-|Office.com  |4345a7b9-9a63-4910-a426-35363201d503|
 |Office.com  |4765445b-32c6-49b0-83e6-1d93765276ca|
 |Office desktop  | 0ec893e0-5785-4de6-99da-4ed124e5296c |
 |Outlook desktop | d3590ed6-52b3-4102-aeff-aad2292ab01c |


### PR DESCRIPTION
We are completing the transition to the new office.com app ID, so listing the old app ID here is no longer required.