### PR TITLE
miss one -

### DIFF
--- a/msteams-platform/sbs-outgoing-webhooks.yml
+++ b/msteams-platform/sbs-outgoing-webhooks.yml
@@ -69,7 +69,7 @@ items:
     1. Use ngrok to create a tunnel to your locally running web server's publicly available HTTPS endpoints. Run the following command in ngrok:
 
         ```bash
-        ngrok http -host-header=localhost 3978
+        ngrok http --host-header=localhost 3978
         ```
 
     1. From the window's lower-right corner, select **Create an Outgoing Webhook**.


### PR DESCRIPTION
miss one -,
ngrok http -host-header=localhost 3978 is not able to start tunnel