### PR TITLE
M365 apps updates from recent feedback

### DIFF
--- a/msteams-platform/m365-apps/overview.md
+++ b/msteams-platform/m365-apps/overview.md
@@ -21,7 +21,7 @@ The Teams app platform continues to evolve and expand holistically into the Micr
 | [**Graph connectors**](/microsoftsearch/connectors-overview)| `graphConnector` | Web, Desktop, Mobile| Web, Desktop | Web| See [notes](#graph-connectors)
 | [**Office Add-ins**](/office/dev/add-ins/develop/json-manifest-overview) (preview) | `extensions` | - | Web, Desktop | - | Only available in [devPreview](../resources/schema/manifest-schema-dev-preview.md) manifest version. See [notes](#office-add-ins-preview).|
 
-\* The [Microsoft 365 Targeted release](/microsoft-365/admin/manage/release-options-in-office-365) option and [Microsoft 365 Apps update channel](/deployoffice/change-update-channels) enrollment require admin opt-in for the entire organization or selected users.
+\* The [Microsoft 365 Targeted release](/microsoft-365/admin/manage/release-options-in-office-365) option and [Microsoft 365 Apps update channel](/deployoffice/change-update-channels) enrollment require admin opt-in for the entire organization or selected users. Update channels are device-specific and apply only to installations of Office running on Windows.
 
 For guidance about the Teams app manifest and SDK versioning guidance, as well as further details about current Teams platform capability support across Microsoft 365, see the [Teams JavaScript client SDK overview](../tabs/how-to/using-teams-client-sdk.md).
 

--- a/msteams-platform/m365-apps/overview.md
+++ b/msteams-platform/m365-apps/overview.md
@@ -17,9 +17,9 @@ The Teams app platform continues to evolve and expand holistically into the Micr
 |          | App manifest element | Teams support |Outlook* support | Office* support | Notes |
 |--|--|--|--|--|--|
 | [**Tabs**](../tabs/what-are-tabs.md) (personal scope)    |`staticTabs`  | Web, Desktop, Mobile | Web (Targeted Release), Desktop (Beta Channel) | Web (Targeted Release)| Channel and group scope not yet supported for Microsoft 365. See [notes](../tabs/how-to/using-teams-client-sdk.md#microsoft-365-support-running-teams-apps-in-office-and-outlook).
-| [**Message extensions**](../messaging-extensions/what-are-messaging-extensions.md) (search-based)| `composeExtensions` | Web, Desktop, Mobile| Web (Targeted Release), Desktop (Beta Channel)| |Action-based not yet supported for Microsoft 365. See [notes](extend-m365-teams-message-extension.md#preview-your-message-extension-in-outlook). |
+| [**Message extensions**](../messaging-extensions/what-are-messaging-extensions.md) (search-based)| `composeExtensions` | Web, Desktop, Mobile| Web (Targeted Release), Desktop (Beta Channel)| - |Action-based not yet supported for Microsoft 365. See [notes](extend-m365-teams-message-extension.md#preview-your-message-extension-in-outlook). |
 | [**Graph connectors**](/microsoftsearch/connectors-overview)| `graphConnector` | Web, Desktop, Mobile| Web, Desktop | Web| See [notes](#graph-connectors)
-| [**Office Add-ins**](/office/dev/add-ins/develop/json-manifest-overview) (preview) | `extensions` | | Web, Desktop  | | Only available in [devPreview](../resources/schema/manifest-schema-dev-preview.md) manifest version. See [notes](#office-add-ins-preview).|
+| [**Office Add-ins**](/office/dev/add-ins/develop/json-manifest-overview) (preview) | `extensions` | - | Web, Desktop | - | Only available in [devPreview](../resources/schema/manifest-schema-dev-preview.md) manifest version. See [notes](#office-add-ins-preview).|
 
 \* The [Microsoft 365 Targeted release](/microsoft-365/admin/manage/release-options-in-office-365) option and [Microsoft 365 Apps update channel](/deployoffice/change-update-channels) enrollment require admin opt-in for the entire organization or selected users.
 

--- a/msteams-platform/m365-apps/overview.md
+++ b/msteams-platform/m365-apps/overview.md
@@ -21,7 +21,7 @@ The Teams app platform continues to evolve and expand holistically into the Micr
 | [**Graph connectors**](/microsoftsearch/connectors-overview)| `graphConnector` | Web, Desktop, Mobile| Web, Desktop | Web| See [notes](#graph-connectors)
 | [**Office Add-ins**](/office/dev/add-ins/develop/json-manifest-overview) (preview) | `extensions` | - | Web, Desktop | - | Only available in [devPreview](../resources/schema/manifest-schema-dev-preview.md) manifest version. See [notes](#office-add-ins-preview).|
 
-\* The [Microsoft 365 Targeted release](/microsoft-365/admin/manage/release-options-in-office-365) option and [Microsoft 365 Apps update channel](/deployoffice/change-update-channels) enrollment require admin opt-in for the entire organization or selected users. Update channels are device-specific and apply only to installations of Office running on Windows.
+\* The [Microsoft 365 Targeted release](/microsoft-365/admin/manage/release-options-in-office-365) option and [Microsoft 365 Apps update channel](/deployoffice/change-update-channels) enrollment require admin opt-in for the entire organization or selected users. Update channels are device specific and apply only to installations of Office running on Windows.
 
 For guidance about the Teams app manifest and SDK versioning guidance, as well as further details about current Teams platform capability support across Microsoft 365, see the [Teams JavaScript client SDK overview](../tabs/how-to/using-teams-client-sdk.md).
 


### PR DESCRIPTION
- Add hyphens to indicate not-supported items in table
- Emphasize that desktop preview support is limited to Office on Windows