### PR TITLE
Update instruction to set up ngrok

### DIFF
--- a/msteams-platform/sbs-botbuilder-linkunfurling.yml
+++ b/msteams-platform/sbs-botbuilder-linkunfurling.yml
@@ -172,10 +172,10 @@ items:
          Use ngrok to create a tunnel to your locally running web server's publicly available HTTPS endpoints. Run the following command in ngrok:
 
        ```bash
-       ngrok http -host-header=localhost 3978
+       ngrok http --host-header=localhost 3978
        ```
        > [!TIP]
-       > If you encounter **ERR_NGROK_4018**, follow the steps, as displayed in the command prompt to sign up and authenticate ngrok. Then run the `ngrok http -host-header=localhost 3978` command.
+       > If you encounter **ERR_NGROK_4018**, follow the steps, as displayed in the command prompt to sign up and authenticate ngrok. Then run the `ngrok http --host-header=localhost 3978` command.
 
     **To add messaging endpoint**
 


### PR DESCRIPTION
According to the ngrok help, should be --host-header instead of -host-header
Validated manually.
![image](https://user-images.githubusercontent.com/84343636/172467495-34344d66-332c-4211-87f2-7bd09732a5c3.png)
