### PR TITLE
Fixed redirect for auth-aad-sso

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -738,7 +738,7 @@
       },
       {
         "source_path": "msteams-platform/platform/tabs/how-to/authentication/auth-aad-sso.md",
-        "redirect_url": "/msteams-platform/platform/tabs/how-to/tab-sso-overview"
+        "redirect_url": "/msteams-platform/platform/tabs/how-to/authentication/tab-sso-overview"
       }
     ]
 }


### PR DESCRIPTION
In 5b90f11da50d06c90379451ed3cb5f2f6c5ecf6b the file `auth-aad-sso.md` was deleted and a redirect was added to `tab-sso-overview.md` but with a missing parent folder, resulting in a 404 error.