### PR TITLE
Update manifest-schema.md

### DIFF
--- a/msteams-platform/resources/schema/manifest-schema.md
+++ b/msteams-platform/resources/schema/manifest-schema.md
@@ -501,7 +501,7 @@ The item is an array (maximum of only one element&mdash;currently only one bot i
 
 ### bots.commandLists
 
-An optional list of commands that your bot can recommend to users. The object is an array (maximum of two elements) with all elements of type `object`; you must define a separate command list for each scope that your bot supports. For more information,see [Bot menus](~/bots/how-to/create-a-bot-commands-menu.md).
+A list of commands that your bot can recommend to users. The object is an array (maximum of two elements) with all elements of type `object`; you must define a separate command list for each scope that your bot supports. For more information,see [Bot menus](~/bots/how-to/create-a-bot-commands-menu.md).
 
 |Name| Type| Maximum size | Required | Description|
 |---|---|---|---|---|


### PR DESCRIPTION
Listing atleast one bot command is mandatory by Teams Store policy. Stating that 'bot command is an optional list is creating confusion with developer. 
Proposed to remove 'optional' word from this section. 

@surbhigupta12 