### PR TITLE
Update debug-background-process.md

### DIFF
--- a/msteams-platform/toolkit/debug-background-process.md
+++ b/msteams-platform/toolkit/debug-background-process.md
@@ -29,7 +29,7 @@ Teams Toolkit checks the following prerequisites during the debug process:
   |Project type|Node.js LTS version|
   |----------|--------------------------------|
   |Tab | 14, 16 (recommended) |
-  |SPFx Tab | 12, 14, 16 (recommended)|
+  |SPFx Tab | 14, 16 (recommended)|
   |Bot |  14, 16 (recommended)|
   |Message extension | 14, 16 (recommended) |
 


### PR DESCRIPTION
Remove Node 12 since according to official Node.js website, the support for 12 is reaching end of life from April 30, 2022