### PR TITLE
Removed blank note block

### DIFF
--- a/msteams-platform/concepts/build-and-test/share-to-teams-from-personal-app-or-tab.md
+++ b/msteams-platform/concepts/build-and-test/share-to-teams-from-personal-app-or-tab.md
@@ -93,9 +93,6 @@ After you enable share to teams button on personal app or tab, you can share the
 
     :::image type="content" source="../../assets/images/share-to-teams/add-recepient.PNG" alt-text="add-recipient":::
 
-    > [!NOTE]
-    > You can add a note in **say something about this**.
-
 3. Select **Share**.
 
    :::image type="content" source="../../assets/images/share-to-teams/add-notes.PNG" alt-text="add-note":::


### PR DESCRIPTION
As tempted as I am to add a second note block with the response "Something about this", this note block should be removed as it is blank.