### PR TITLE
[Doc Feature][Support meeting start or end event in channel meeting][2014851]

### DIFF
--- a/msteams-platform/graph-api/rsc/resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/resource-specific-consent.md
@@ -31,6 +31,7 @@ The granular, Teams-specific, RSC permissions define what an application can do 
 |Channel.Create.Group|Create channels in this team. |
 |Channel.Delete.Group|Delete channels in this team. |
 |ChannelMessage.Read.Group |Get this team's channel messages. |
+|ChannelMeeting.ReadBasic.Group|Receive meeting events from channel meetings. |
 |TeamsAppInstallation.Read.Group|Get a list of this team's installed apps.|
 |TeamsTab.Read.Group|Get a list of this team's tabs.|
 |TeamsTab.Create.Group|Create tabs in this team. |

--- a/msteams-platform/graph-api/rsc/test-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/test-resource-specific-consent.md
@@ -213,6 +213,7 @@ Example for RSC in a team
         "Channel.Create.Group",
         "Channel.Delete.Group",
         "ChannelMessage.Read.Group",
+        "ChannelMeeting.ReadBasic.Group",
         "TeamsAppInstallation.Read.Group",
         "TeamsTab.Read.Group",
         "TeamsTab.Create.Group",


### PR DESCRIPTION
added "ChannelMeeting.ReadBasic.Group", in RSC docs.