### PR TITLE
[Doc Improvement] [Update people picker note]

### DIFF
--- a/msteams-platform/task-modules-and-cards/cards/people-picker.md
+++ b/msteams-platform/task-modules-and-cards/cards/people-picker.md
@@ -9,9 +9,6 @@ ms.author: surbhigupta
 
 # People Picker in Adaptive Cards
 
->[!NOTE]
-> Currently, People Picker in Adaptive Cards is available in [Public developer preview for Teams](../../resources/dev-preview/developer-preview-intro.md#public-developer-preview-for-teams) only for mobile and generally available (GA) for desktop.
-
 People Picker helps users to search and select users in Adaptive Card. You can add People Picker as input control to Adaptive Card, which works across chats, channels, task modules, and tabs. People Picker supports the following features:
 
 * Searches single or multiple users.


### PR DESCRIPTION
Removed note that People Picker in Adaptive Cards is available in public developer preview for Teams.