### PR TITLE
[Doc Issue][Update teams live share tutorial][2855569]

### DIFF
--- a/msteams-platform/apps-in-teams-meetings/teams-live-share-tutorial.md
+++ b/msteams-platform/apps-in-teams-meetings/teams-live-share-tutorial.md
@@ -336,7 +336,7 @@ Users invited to the meeting can see your app on stage when they join the meetin
 
 ## Deployment
 
-After you're ready to deploy your code, you can use [Teams Toolkit(../toolkit/provision.md#provision-using-teams-toolkit-in-visual-studio) or the [Teams Developer Portal](https://dev.teams.microsoft.com/apps) to provision and upload your app's zip file.
+After you're ready to deploy your code, you can use [Teams Toolkit](../toolkit/provision.md#provision-using-teams-toolkit-in-visual-studio) or the [Teams Developer Portal](https://dev.teams.microsoft.com/apps) to provision and upload your app's zip file.
 
 > [!NOTE]
 > You need to add your provisioned appId to the `manifest.json` before uploading or distributing the app.


### PR DESCRIPTION
updated the following broken link:

![image](https://user-images.githubusercontent.com/93579821/214225741-711e4798-647b-4ada-8d81-75bd0a2e13ba.png)
