### PR TITLE
[Doc Improvement] Remove OWA appid that is no longer needed

### DIFF
--- a/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
+++ b/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
@@ -144,7 +144,6 @@ Azure Active Directory (AD) single sign-on (SSO) for message extensions works th
    |Teams desktop and mobile |1fec8e78-bce4-4aaf-ab1b-5451cc387264 |
    |Teams web |5e3ce6c0-2b1f-4285-8d4b-75ee78787346 |
    |Outlook desktop | d3590ed6-52b3-4102-aeff-aad2292ab01c |
-   |Outlook Web Access | 00000002-0000-0ff1-ce00-000000000000 |
    |Outlook Web Access | bc59ab01-8403-45c6-8796-ac3ef710b3e3 |
    |Outlook mobile | 27922004-5251-4030-b22d-91ecd9a37ea4 |
 


### PR DESCRIPTION
Remove an Outlook web appid from the table of required app registrations for SSO of cross-host apps as it's no longer needed.