### PR TITLE
[Doc issue] Update deep-link-teams.md

### DIFF
--- a/msteams-platform/concepts/build-and-test/deep-link-teams.md
+++ b/msteams-platform/concepts/build-and-test/deep-link-teams.md
@@ -61,9 +61,9 @@ The query parameters are:
 
 Use the following deep link format to navigate a user to a message in a personal or group chat in Teams:
 
-`http://teams.microsoft.com/l/message/{chatId}/{messageId}?context={"contextType":"chat"}`
+`https://teams.microsoft.com/l/message/{chatId}/{messageId}?context={"contextType":"chat"}`
 
-Example: `http://teams.microsoft.com/l/message/19:253f5895-9a62-4362-8d38-43f0205c702c_f1b94dcf-0aa3-4989-bcdf-ef4a5ed00f86@unq.gbl.spaces/1563480968434?context=%7B%22contextType%22:%22chat%22%7D`
+Example: `https://teams.microsoft.com/l/message/19:253f5895-9a62-4362-8d38-43f0205c702c_f1b94dcf-0aa3-4989-bcdf-ef4a5ed00f86@unq.gbl.spaces/1563480968434?context=%7B%22contextType%22:%22chat%22%7D`
 
 The query parameters are:
 


### PR DESCRIPTION
use https instead of http. 
With http, the teams will open in browser or open in new tab(Web teams). With https, the teams will open the chat directly.