### PR TITLE
[Doc Issue][Update TTK support for GCC clouds]

### DIFF
--- a/msteams-platform/toolkit/teams-toolkit-fundamentals.md
+++ b/msteams-platform/toolkit/teams-toolkit-fundamentals.md
@@ -12,9 +12,9 @@ ms.date: 05/24/2022
 
 > [!IMPORTANT]
 >
-> We've introduced the Teams Toolkit v5 extension within Visual Studio Code. This version comes to you with many new app development features. We recommend that you use Teams Toolkit v5 for building your Teams app.
->
-> [Teams Toolkit v4](toolkit-v4/teams-toolkit-fundamentals-v4.md) extension will soon be deprecated.
+> * We've introduced the Teams Toolkit v5 extension within Visual Studio Code. This version comes to you with many new app development features. We recommend that you use Teams Toolkit v5 for building your Teams app.
+> * Teams Toolkit isn't supported in Government Community Cloud (GCC) and GCC-High environments.
+> * [Teams Toolkit v4](toolkit-v4/teams-toolkit-fundamentals-v4.md) extension will soon be deprecated.
 
 Teams Toolkit makes it simple to get started with app development for Microsoft Teams using Visual Studio Code.
 


### PR DESCRIPTION
updated Teams Toolkit isn't supported in Government Community Cloud (GCC) and GCC-High environments.