### PR TITLE
Update M365 prereqs with interim ring until 100% Current Channel rollout

### DIFF
--- a/msteams-platform/m365-apps/prerequisites.md
+++ b/msteams-platform/m365-apps/prerequisites.md
@@ -71,7 +71,7 @@ For more information on Microsoft 365 release options, see [set up the Standard 
 
 ### Desktop
 
-You can preview Teams apps running in Outlook on Windows desktop by using a recent *Current Channel (Preview)*. Check if you have to [change the Microsoft 365 Apps update channel](/deployoffice/change-update-channels?WT.mc_id=M365-MVP-5002016) for your test tenant to install a Microsoft 365 Current Channel (Preview) build.
+You can preview Teams apps running in Outlook on Windows desktop by using a recent *Current Channel (Preview)* build. Check if you have to [change the Microsoft 365 Apps update channel](/deployoffice/change-update-channels?WT.mc_id=M365-MVP-5002016) for your test tenant to install a Microsoft 365 Current Channel (Preview) build.
 
 To install Microsoft 365 applications in your test environment:
 

--- a/msteams-platform/m365-apps/prerequisites.md
+++ b/msteams-platform/m365-apps/prerequisites.md
@@ -71,20 +71,18 @@ For more information on Microsoft 365 release options, see [set up the Standard 
 
 ### Desktop
 
-You can preview Teams apps running in Outlook on Windows desktop by using a recent *Current Channel build*. Check if you have to [change the Microsoft 365 Apps update channel](/deployoffice/change-update-channels?WT.mc_id=M365-MVP-5002016) for your test tenant to install a Microsoft 365 Current Channel build.
+You can preview Teams apps running in Outlook on Windows desktop by using a recent *Current Channel (Preview)*. Check if you have to [change the Microsoft 365 Apps update channel](/deployoffice/change-update-channels?WT.mc_id=M365-MVP-5002016) for your test tenant to install a Microsoft 365 Current Channel (Preview) build.
 
 To install Microsoft 365 applications in your test environment:
 
 1. Sign in to your test environment with your test tenant credentials.
 1. Download and run the [Office Deployment Tool](https://www.microsoft.com/download/details.aspx?id=49117).
 1. Select a local folder to store the extracted files.
-1. Go to the local folder and open *configuration-Office365-x86.xml* (or **x64.xml*, depending on your environment) in a text editor and ensure the *Channel* value is `Current`.
+1. Go to the local folder and open *configuration-Office365-x86.xml* (or **x64.xml*, depending on your environment) in a text editor and ensure the *Channel* value is `CurrentPreview`.
 1. Open Command Prompt and go to the local folder path.
 1. Run `setup.exe /configure configuration-Office365-x86.xml` (or use the **x64.xml* file, depending on your setup).
 1. Open Outlook (desktop client) and set up the mail account using your test tenant credentials.
-1. Open **File** > **Office Account** > **About Outlook** to confirm you're running a Microsoft 365 *Current Channel* build of Outlook.
-
-    :::image type="content" source="images/outlook-about-current-channel.png" alt-text="The screenshot shows where to verify you're running a Current Channel build in Outlook.":::
+1. Open **File** > **Office Account** > **About Outlook** to confirm you're running a Microsoft 365 *Current Channel (Preview)* build of Outlook.
 
 1. Verify that *Microsoft Edge WebView2 Runtime* is installed. Open Windows **Start** > **Apps & features**, and search for **webview**:
 


### PR DESCRIPTION
While Channel=Current works for Microsoft internal users, external rollout will take a couple months to reach 100%. Updating M365 app instructions to use `CurrentPreview` in the interim for testing their apps.