### PR TITLE
Add warning about new ME bot channel requirement for Outlook

### DIFF
--- a/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
+++ b/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
@@ -115,11 +115,11 @@ If you used Teams Toolkit to create your message extension app, you can use it t
 
 In Microsoft Teams, a message extension consists of a web service that you host and an app manifest, which defines where your web service is hosted. The web service takes advantage of the [Bot Framework SDK](/azure/bot-service/bot-service-overview) messaging schema and secure communication protocol through a Teams channel registered for your bot.
 
-For users to interact with your message extension from Outlook, you need to enable the *Microsoft 365* channel for your bot in Azure.
+For users to interact with your message extension from Outlook, you need to enable the *Microsoft 365* channel for your Azure bot resource (message extension).
 
 > [!NOTE]
 >
-> If you previously enabled the *Outlook* channel for your bot, you'll need to now enable **Microsoft 365** channel in order for your message extension to continue functioning correctly in Outlook. The *Outlook* channel is no longer needed for message extensions running in Outlook and can be disabled.
+> If you previously enabled the *Outlook* channel for your bot, you'll need to now enable **Microsoft 365** channel in order for your message extension to continue functioning correctly in Outlook. The *Outlook* channel is no longer used for message extensions running in Outlook and can be disabled.
 
 1. From [Microsoft Azure portal](https://portal.azure.com) (or [Bot Framework portal](https://dev.botframework.com) if you previously registered there), go to your bot resource.
 

--- a/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
+++ b/msteams-platform/m365-apps/extend-m365-teams-message-extension.md
@@ -10,9 +10,9 @@ ms.subservice: m365apps
 ---
 # Extend a Teams message extension across Microsoft 365
 
-> [!NOTE]
+> [!IMPORTANT]
 >
-> If you've connected your message extension bot to an **Outlook** channel, you must migrate to the **Microsoft 365** channel.
+> The **Microsoft 365** channel replaces the previous *Outlook* channel for message extensions running in Outlook. Existing message extensions require [Azure Bot registration for the Microsoft 365 channel](#add-microsoft-365-channel-for-your-bot) in order to continue working correctly in Outlook.
 
 Search-based [message extensions](/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions) allow users to search an external system and share results through the compose message area of the Microsoft Teams client. You can now bring production search-based Teams message extensions to preview audiences in Outlook for Windows desktop and outlook.com by [extending your Teams apps across Microsoft 365](overview.md).
 
@@ -115,7 +115,11 @@ If you used Teams Toolkit to create your message extension app, you can use it t
 
 In Microsoft Teams, a message extension consists of a web service that you host and an app manifest, which defines where your web service is hosted. The web service takes advantage of the [Bot Framework SDK](/azure/bot-service/bot-service-overview) messaging schema and secure communication protocol through a Teams channel registered for your bot.
 
-For users to interact with your message extension from Outlook, you need to add Microsoft 365 channel to your bot:
+For users to interact with your message extension from Outlook, you need to enable the *Microsoft 365* channel for your bot in Azure.
+
+> [!NOTE]
+>
+> If you previously enabled the *Outlook* channel for your bot, you'll need to now enable **Microsoft 365** channel in order for your message extension to continue functioning correctly in Outlook. The *Outlook* channel is no longer needed for message extensions running in Outlook and can be disabled.
 
 1. From [Microsoft Azure portal](https://portal.azure.com) (or [Bot Framework portal](https://dev.botframework.com) if you previously registered there), go to your bot resource.
 


### PR DESCRIPTION
Updating docs to warn customers that Outlook->M365 channel migration is a breaking change and there is no back compat support.