### PR TITLE
Adding information regarding the switch from Group Owner Consent to Team RSC

### DIFF
--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -429,9 +429,9 @@ Admins will adjust Team RSC and Chat RSC settings via PowerShell cmdlets. Below 
 
 | PowerShell State | Description |
 | ---- | :---- |
-| ManagedByMicrosoft |  This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts discretion |
-| EnabledForAllApps |  Any app requesting RSC permissions can be consented to by users (resource owners) in your tenant |
-| DisabledForAllApps|  No RSC permissions can be consented to by users. |
+| ManagedByMicrosoft | This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts discretion |
+| EnabledForAllApps | Any app requesting RSC permissions can be consented to by users (resource owners) in your tenant |
+| DisabledForAllApps | No RSC permissions can be consented to by users. |
 <br>
 <details>
 

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -425,7 +425,7 @@ Admins will adjust Team RSC and Chat RSC settings via PowerShell cmndlets. Below
 
 | PowerShell State | Description |
 | ---- | :----: |
-| ManagedByMicrosoft |  This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts' discretion |
+| ManagedByMicrosoft |  This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts discretion |
 | ApprovedForAllApps |  Any RSC enabled app can be consented to by users in your tenant. With these settings enabled, preapproval of RSC permissions is not needed as all RSC enabled apps are approved for use |
 | ApprovedForPreApprovedApps |  RSC enabled apps can be consented on an app-by-app basis. Admins can choose which apps are approved for which RSC permissions. |
 | DisabledForAllApps|  No RSC permissions can be consented to by users. In this state, preapproval of RSC permissions will have no effect on users ability to consent to RSC enabled apps |

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -431,7 +431,7 @@ You can configure which users are allowed to consent to apps accessing their Tea
 [PS]
 
 </details>
-
+<br>
 <details>
 
 <summary><b>Configure Chat RSC via PowerShell cmndlets</b></summary>

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -381,7 +381,7 @@ In addition, you can enable or disable group owner consent using PowerShell. Fol
 <summary><b>Configure chat owner consent settings for RSC in a chat using Graph APIs [Will be deprecated in May 2024]</b></summary>
 
 >[!IMPORTANT]
->After March 14th, 2024 Microsoft suggests disabling this setting and utlizing the PowerShell cmdlets listed below to manage your Chat RSC settings. See the section below titled "Configure Chat RSC via PowerShell cmdlets".
+>After March 14th, you will need to use PowerShell cmdlets listed below to manage your Chat RSC settings. See the section below titled "Configure Chat RSC via PowerShell cmdlets".
 
 You can enable or disable RSC for chats using Graph API. The property `isChatResourceSpecificConsentEnabled` in [teamsAppSettings](/graph/api/teamsappsettings-update#example-1-enable-installation-of-apps-that-require-resource-specific-consent-in-chats-meetings) governs whether chat RSC is enabled in the tenant.
 
@@ -428,11 +428,11 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 Admins will adjust Team RSC and Chat RSC settings via PowerShell cmdlets. Below are the available states for the PowerShell settings. Each section below will show examples of how to use these states to adjust your settings.
 
 | PowerShell State | Description |
-| ---- | :----: |
+| ---- | :---- |
 | ManagedByMicrosoft |  This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts discretion |
 | EnabledForAllApps |  Any app requesting RSC permissions can be consented to by users (resource owners) in your tenant |
 | DisabledForAllApps|  No RSC permissions can be consented to by users. |
-
+<br>
 <details>
 
 <summary><b>Configure Team RSC via PowerShell cmdlets</b></summary>

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -346,12 +346,13 @@ To install your app on which you've enabled RSC permission in a team, chat, or u
 1. [Upload your custom app in Teams](#upload-your-custom-app-in-teams).
 
 ### Configure consent settings
->[!WARNING]
->The way you manage settings for application RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify
 
 The tenant-level controls of application RSC permissions vary based on the resource type.
 
 For delegated permissions, any authorized user can consent to the permissions requested by the app.
+
+>[!WARNING]
+>The way you manage settings for application RSC and chat RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify
 
 <b> Before March 14th, 2024 </b>
 
@@ -419,6 +420,15 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 <br>
 
 <b> After March 14th, 2024 </b>
+
+| PowerShell State | Description |
+| ---- | :----: |
+| ManagedByMicrosoft |  Any RSC enabled app can be consented to by users in your tenant. With these settings enabled, preapproval of RSC permissions is not needed as all RSC enabled apps are approved for use. These settings are managed by Microsoft and may be changed at any time |
+| ApprovedForAllApps |  Any RSC enabled app can be consented to by users in your tenant. With these settings enabled, preapproval of RSC permissions is not needed as all RSC enabled apps are approved for use |
+| ApprovedForPreApprovedApps |  RSC enabled apps can be consented on an app-by-app basis. Admins can choose which apps are approved for which RSC permissions. |
+| DisabledForAllApps|  No RSC permissions can be consented to by users. In this state, preapproval of RSC permissions will have no effect on users ability to consent to RSC enabled apps |
+
+
 
 <details>
 

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -352,7 +352,7 @@ The tenant-level controls of application RSC permissions vary based on the resou
 For delegated permissions, any authorized user can consent to the permissions requested by the app.
 
 >[!WARNING]
->The way you manage settings for team RSC and chat RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify
+>The way you manage settings for team RSC and chat RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify. These setting will not change for governmnet clouds and seperate communication will be sent when those settings are changed.
 
 <b> Before March 14th, 2024 </b>
 
@@ -361,7 +361,7 @@ For delegated permissions, any authorized user can consent to the permissions re
 <summary><b>Configure group owner consent settings for RSC in a team using the Microsoft Entra admin center [Will be deprecated in March 2024]</b></summary>
 
 >[!IMPORTANT]
->After March 14th, 2024 this setting will be deprecated and longer available for adjustments. At that time, please utilize the PowerShell cmndlets listed below to adjust your Team RSC setttings. See the section below titled "Configure Team RSC via PowerShell cmndlets".
+>After March 14th, 2024 this setting will be deprecated and no longer available for adjustments. From that time, please utilize the PowerShell cmdlets listed below to adjust your Team RSC setttings. See the section below titled "Configure Team RSC via PowerShell cmdlets".
 
 You can enable or disable group owner consent directly within the Microsoft Entra admin center:
 
@@ -378,10 +378,10 @@ In addition, you can enable or disable group owner consent using PowerShell. Fol
 <br>
 <details>
 
-<summary><b>Configure chat owner consent settings for RSC in a chat using the Graph APIs [Will be deprecated in May 2024]</b></summary>
+<summary><b>Configure chat owner consent settings for RSC in a chat using Graph APIs [Will be deprecated in May 2024]</b></summary>
 
 >[!IMPORTANT]
->After March 14th, 2024 Microsoft suggests disabling this setting and utlizing the PowerShell cmndlets listed below to manage your Chat RSC settings. See the section below titled "Configure Chat RSC via PowerShell cmndlets".
+>After March 14th, 2024 Microsoft suggests disabling this setting and utlizing the PowerShell cmdlets listed below to manage your Chat RSC settings. See the section below titled "Configure Chat RSC via PowerShell cmdlets".
 
 You can enable or disable RSC for chats using Graph API. The property `isChatResourceSpecificConsentEnabled` in [teamsAppSettings](/graph/api/teamsappsettings-update#example-1-enable-installation-of-apps-that-require-resource-specific-consent-in-chats-meetings) governs whether chat RSC is enabled in the tenant.
 
@@ -421,21 +421,20 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 
 <b> After March 14th, 2024 </b>
 
-Admins will adjust Team RSC and Chat RSC settings via PowerShell cmndlets. Below are the available states for the PowerShell settings. Each section below will show examples of how to use these states to adjust your settings.
+Admins will adjust Team RSC and Chat RSC settings via PowerShell cmdlets. Below are the available states for the PowerShell settings. Each section below will show examples of how to use these states to adjust your settings.
 
 | PowerShell State | Description |
 | ---- | :----: |
 | ManagedByMicrosoft |  This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts discretion |
-| ApprovedForAllApps |  Any RSC enabled app can be consented to by users in your tenant. With these settings enabled, preapproval of RSC permissions is not needed as all RSC enabled apps are approved for use |
-| ApprovedForPreApprovedApps |  RSC enabled apps can be consented on an app-by-app basis. Admins can choose which apps are approved for which RSC permissions. |
-| DisabledForAllApps|  No RSC permissions can be consented to by users. In this state, preapproval of RSC permissions will have no effect on users ability to consent to RSC enabled apps |
+| EnabledForAllApps |  Any app requesting RSC permissions can be consented to by users (resource owners) in your tenant |
+| DisabledForAllApps|  No RSC permissions can be consented to by users. |
 
 <details>
 
-<summary><b>Configure Team RSC via PowerShell cmndlets</b></summary>
+<summary><b>Configure Team RSC via PowerShell cmdlets</b></summary>
 <br>
 
-You can configure which users are allowed to consent to apps accessing their Teams' data by using the available PowerShell states. ApprovedForAllApps, ApprovedForPreApprovedApps, & DisabledForAllApps
+You can configure which users are allowed to consent to apps accessing their Teams' data by using the available PowerShell states. EnabledForAllApps,ManagedByMicrosoft, & DisabledForAllApps
 <br>
 
 Below is an example of how to disable Team RSC for all apps: 
@@ -449,10 +448,10 @@ Set-MgBetaTeamRscConfiguration -State DisabledForAllApps
 <br>
 <details>
 
-<summary><b>Configure Chat RSC via PowerShell cmndlets</b></summary>
+<summary><b>Configure Chat RSC via PowerShell cmdlets</b></summary>
 <br>
 
-You can configure which users are allowed to consent to apps accessing their Chats' data by using the available PowerShell states. ApprovedForAllApps, ApprovedForPreApprovedApps, & DisabledForAllApps
+You can configure which users are allowed to consent to apps accessing their Chats' data by using the available PowerShell states. EnabledForAllApps, ManagedByMicrosoft, & DisabledForAllApps
 <br>
 
 Below is an example of how to disable Chat RSC for all apps: 

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -432,6 +432,7 @@ Admins adjust team and chat RSC settings through PowerShell cmdlets. The followi
 | ManagedByMicrosoft | This is the default state for all tenants. It allows chat and team RSC permissions to be consented for all users but can be changed at any time at Microsoft's discretion. |
 | EnabledForAllApps | Any app requesting RSC permissions can be consented to by users (resource owners) in your tenant. |
 | DisabledForAllApps | No RSC permissions can be consented to by users. |
+
 <br>
 <details>
 

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -352,7 +352,7 @@ The tenant-level controls of application RSC permissions vary based on the resou
 For delegated permissions, any authorized user can consent to the permissions requested by the app.
 
 >[!WARNING]
->The way you manage settings for team RSC and chat RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify. These setting will not change for governmnet clouds and seperate communication will be sent when those settings are changed.
+>The way you manage settings for team RSC and chat RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify. These settings will not change for government clouds and separate communication will be sent when those settings are changed.
 
 <b> Before March 14th, 2024 </b>
 
@@ -417,6 +417,10 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 
 </details>
 
+<br>
+
+>[!IMPORTANT]
+>The pre-selection period for the transition from Group Owner Consent to PowerShell based Team RSC has started and will remain active through March 4th, 2024. After then, the transition to Team RSC policies managed by PowerShell will begin
 <br>
 
 <b> After March 14th, 2024 </b>

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -360,7 +360,7 @@ For delegated permissions, any authorized user can consent to the permissions re
 <summary><b>Configure group owner consent settings for RSC in a team using the Microsoft Entra admin center [Will be deprecated in March 2024]</b></summary>
 
 >[!IMPORTANT]
->After March 14th, 2024 this setting will be deprecated and longer available for adjustments. At that time, please utilize the PowerShell cmndlets listed below to adjust your Team RSC setttings.
+>After March 14th, 2024 this setting will be deprecated and longer available for adjustments. At that time, please utilize the PowerShell cmndlets listed below to adjust your Team RSC setttings. See the section below titled "Configure Team RSC via PowerShell cmndlets".
 
 You can enable or disable group owner consent directly within the Microsoft Entra admin center:
 
@@ -380,7 +380,7 @@ In addition, you can enable or disable group owner consent using PowerShell. Fol
 <summary><b>Configure chat owner consent settings for RSC in a chat using the Graph APIs [Will be deprecated in May 2024]</b></summary>
 
 >[!IMPORTANT]
->After March 14th, 2024 Microsoft suggests disabling this setting and utlizing the PowerShell cmndlets listed below to manage your Chat RSC settings.
+>After March 14th, 2024 Microsoft suggests disabling this setting and utlizing the PowerShell cmndlets listed below to manage your Chat RSC settings. See the section below titled "Configure Chat RSC via PowerShell cmndlets".
 
 You can enable or disable RSC for chats using Graph API. The property `isChatResourceSpecificConsentEnabled` in [teamsAppSettings](/graph/api/teamsappsettings-update#example-1-enable-installation-of-apps-that-require-resource-specific-consent-in-chats-meetings) governs whether chat RSC is enabled in the tenant.
 
@@ -439,6 +439,24 @@ You can configure which users are allowed to consent to apps accessing their Tea
 You can enable or disable Chat RSC via PowerShell cmndlets:
 
 [PS]
+
+</details>
+<br>
+<details>
+
+<summary><b>Configure user owner consent settings for RSC for a user using the Graph APIs</b></summary>
+
+You can enable or disable RSC for user using Graph API. The property `isUserPersonalScopeResourceSpecificConsentEnabled` in [teamsAppSettings](/graph/api/teamsappsettings-update#example-1-enable-installation-of-apps-that-require-resource-specific-consent-in-chats-meetings) governs whether user RSC is enabled in the tenant.
+
+:::image type="content" source="../../assets/images/rsc/graph-rsc-user-configuration.PNG" alt-text="The screenshot shows the Graph RSC user configuration.":::
+
+The default value of the property `isUserPersonalScopeResourceSpecificConsentEnabled` is based on whether [user consent settings](/azure/active-directory/manage-apps/configure-user-consent?tabs=azure-portal) is turned on or off in the tenant when RSC for user is first used. The default value is defined either when:
+
+* [TeamsAppSettings](/graph/api/teamsappsettings-get) are retrieved for the first time.
+* Teams app with RSC permissions is installed for a user.
+
+> [!NOTE]
+> Admin control is added to allow or block RSC consent settings based on the sensitivity of the data accessed. It isn't based on the single master switch that enables or disables consent settings for app RSC permissions for all apps in the tenant.
 
 </details>
 

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -352,16 +352,16 @@ The tenant-level controls of application RSC permissions vary based on the resou
 For delegated permissions, any authorized user can consent to the permissions requested by the app.
 
 >[!WARNING]
->The way you manage settings for team RSC and chat RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify. These settings will not change for government clouds and separate communication will be sent when those settings are changed.
+> From March 2024, the way you manage settings for team and chat RSC permissions will change. The following instructions include the dates when new settings will be available for admins to modify. These settings will not change for government clouds and we will communicate when the settings change for government clouds.
 
 <b> Before March 14th, 2024 </b>
-
+<br>
 <details>
 
 <summary><b>Configure group owner consent settings for RSC in a team using the Microsoft Entra admin center [Will be deprecated in March 2024]</b></summary>
 
 >[!IMPORTANT]
->After March 14th, 2024 this setting will be deprecated and no longer available for adjustments. From that time, please utilize the PowerShell cmdlets listed below to adjust your Team RSC setttings. See the section below titled "Configure Team RSC via PowerShell cmdlets".
+>After March 14th, 2024, this setting will be deprecated and no longer available for adjustments. After it is deprecated, use the PowerShell cmdlets listed in **Configure team RSC via PowerShell cmdlets** to adjust your team RSC settings.
 
 You can enable or disable group owner consent directly within the Microsoft Entra admin center:
 
@@ -381,7 +381,7 @@ In addition, you can enable or disable group owner consent using PowerShell. Fol
 <summary><b>Configure chat owner consent settings for RSC in a chat using Graph APIs [Will be deprecated in May 2024]</b></summary>
 
 >[!IMPORTANT]
->After March 14th, you will need to use PowerShell cmdlets listed below to manage your Chat RSC settings. See the section below titled "Configure Chat RSC via PowerShell cmdlets".
+>After March 14, you must use the PowerShell cmdlets listed in **Configure chat RSC via PowerShell cmdlets** to manage your chat RSC settings.
 
 You can enable or disable RSC for chats using Graph API. The property `isChatResourceSpecificConsentEnabled` in [teamsAppSettings](/graph/api/teamsappsettings-update#example-1-enable-installation-of-apps-that-require-resource-specific-consent-in-chats-meetings) governs whether chat RSC is enabled in the tenant.
 
@@ -420,28 +420,28 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 <br>
 
 >[!IMPORTANT]
->The pre-selection period for the transition from Group Owner Consent to PowerShell based Team RSC has started and will remain active through March 4th, 2024. After then, the transition to Team RSC policies managed by PowerShell will begin
+>The pre-selection period for the transition from Group Owner Consent to PowerShell-based team RSC has started and remains active until March 4, 2024. After that, the transition to team RSC policies is managed by PowerShell.
 <br>
 
 <b> After March 14th, 2024 </b>
 
-Admins will adjust Team RSC and Chat RSC settings via PowerShell cmdlets. Below are the available states for the PowerShell settings. Each section below will show examples of how to use these states to adjust your settings.
+Admins adjust team and chat RSC settings through PowerShell cmdlets. The following are the available states for the PowerShell settings and each section shows examples of how to use these states to adjust your settings:
 
 | PowerShell State | Description |
 | ---- | ---- |
-| ManagedByMicrosoft | This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts discretion |
-| EnabledForAllApps | Any app requesting RSC permissions can be consented to by users (resource owners) in your tenant |
+| ManagedByMicrosoft | This is the default state for all tenants. It allows chat and team RSC permissions to be consented for all users but can be changed at any time at Microsoft's discretion. |
+| EnabledForAllApps | Any app requesting RSC permissions can be consented to by users (resource owners) in your tenant. |
 | DisabledForAllApps | No RSC permissions can be consented to by users. |
 <br>
 <details>
 
-<summary><b>Configure Team RSC via PowerShell cmdlets</b></summary>
+<summary><b>Configure team RSC through PowerShell cmdlets</b></summary>
 <br>
 
-You can configure which users are allowed to consent to apps accessing their Teams' data by using the available PowerShell states. EnabledForAllApps,ManagedByMicrosoft, & DisabledForAllApps
+You can configure which users are allowed to consent to apps accessing their teams' data by using the available PowerShell states, such as ManagedByMicrosoft, EnabledForAllApps, and DisabledForAllApps.
 <br>
 
-Below is an example of how to disable Team RSC for all apps: 
+The following example shows how to disable team RSC for all apps: 
 <br>
 
 ```powershell
@@ -452,13 +452,13 @@ Set-MgBetaTeamRscConfiguration -State DisabledForAllApps
 <br>
 <details>
 
-<summary><b>Configure Chat RSC via PowerShell cmdlets</b></summary>
+<summary><b>Configure chat RSC through PowerShell cmdlets</b></summary>
 <br>
 
-You can configure which users are allowed to consent to apps accessing their Chats' data by using the available PowerShell states. EnabledForAllApps, ManagedByMicrosoft, & DisabledForAllApps
+You can configure which users are allowed to consent to apps accessing their chats' data by using the available PowerShell states, such as ManagedByMicrosoft, EnabledForAllApps, and DisabledForAllApps.
 <br>
 
-Below is an example of how to disable Chat RSC for all apps: 
+The following example shows how to disable chat RSC for all apps: 
 <br>
 
 ```powershell
@@ -471,11 +471,11 @@ Set-MgBetaChatRscConfiguration -State DisabledForAllApps
 
 <summary><b>Configure user owner consent settings for RSC for a user using the Graph APIs</b></summary>
 
-You can enable or disable RSC for user using Graph API. The property `isUserPersonalScopeResourceSpecificConsentEnabled` in [teamsAppSettings](/graph/api/teamsappsettings-update#example-1-enable-installation-of-apps-that-require-resource-specific-consent-in-chats-meetings) governs whether user RSC is enabled in the tenant.
+You can enable or disable RSC for user using Graph API. The `isUserPersonalScopeResourceSpecificConsentEnabled` property in [teamsAppSettings](/graph/api/teamsappsettings-update#example-1-enable-installation-of-apps-that-require-resource-specific-consent-in-chats-meetings) governs whether user RSC is enabled in the tenant.
 
 :::image type="content" source="../../assets/images/rsc/graph-rsc-user-configuration.PNG" alt-text="The screenshot shows the Graph RSC user configuration.":::
 
-The default value of the property `isUserPersonalScopeResourceSpecificConsentEnabled` is based on whether [user consent settings](/azure/active-directory/manage-apps/configure-user-consent?tabs=azure-portal) is turned on or off in the tenant when RSC for user is first used. The default value is defined either when:
+The default value of the `isUserPersonalScopeResourceSpecificConsentEnabled` property is based on whether [user consent settings](/azure/active-directory/manage-apps/configure-user-consent?tabs=azure-portal) is turned on or off in the tenant when RSC for user is first used. The default value is defined either when:
 
 * [TeamsAppSettings](/graph/api/teamsappsettings-get) are retrieved for the first time.
 * Teams app with RSC permissions is installed for a user.

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -442,11 +442,11 @@ Admins adjust team and chat RSC settings through PowerShell cmdlets. The followi
 You can configure which users are allowed to consent to apps accessing their teams' data by using the available PowerShell states, such as ManagedByMicrosoft, EnabledForAllApps, and DisabledForAllApps.
 <br>
 
-The following example shows how to disable team RSC for all apps: 
+The following example shows how to enable team RSC for all apps: 
 <br>
 
 ```powershell
-Set-MgBetaTeamRscConfiguration -State DisabledForAllApps
+Set-MgBetaTeamRscConfiguration -State EnabledForAllApps
 ```
 
 </details>
@@ -459,11 +459,11 @@ Set-MgBetaTeamRscConfiguration -State DisabledForAllApps
 You can configure which users are allowed to consent to apps accessing their chats' data by using the available PowerShell states, such as ManagedByMicrosoft, EnabledForAllApps, and DisabledForAllApps.
 <br>
 
-The following example shows how to disable chat RSC for all apps: 
+The following example shows how to enable chat RSC for all apps: 
 <br>
 
 ```powershell
-Set-MgBetaChatRscConfiguration -State DisabledForAllApps
+Set-MgBetaChatRscConfiguration -State EnabledForAllApps
 ```
 
 </details>

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -425,7 +425,7 @@ Admins will adjust Team RSC and Chat RSC settings via PowerShell cmndlets. Below
 
 | PowerShell State | Description |
 | ---- | :----: |
-| ManagedByMicrosoft |  This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsoft's discretion |
+| ManagedByMicrosoft |  This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts' discretion |
 | ApprovedForAllApps |  Any RSC enabled app can be consented to by users in your tenant. With these settings enabled, preapproval of RSC permissions is not needed as all RSC enabled apps are approved for use |
 | ApprovedForPreApprovedApps |  RSC enabled apps can be consented on an app-by-app basis. Admins can choose which apps are approved for which RSC permissions. |
 | DisabledForAllApps|  No RSC permissions can be consented to by users. In this state, preapproval of RSC permissions will have no effect on users ability to consent to RSC enabled apps |

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -346,15 +346,21 @@ To install your app on which you've enabled RSC permission in a team, chat, or u
 1. [Upload your custom app in Teams](#upload-your-custom-app-in-teams).
 
 ### Configure consent settings
+>[!WARNING]
+>The way you manage settings for application RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify
 
 The tenant-level controls of application RSC permissions vary based on the resource type.
 
 For delegated permissions, any authorized user can consent to the permissions requested by the app.
 
-<br>
+<b> Before March 14th, 2024 </b>
+
 <details>
 
-<summary><b>Configure group owner consent settings for RSC in a team using the Microsoft Entra admin center</b></summary>
+<summary><b>Configure group owner consent settings for RSC in a team using the Microsoft Entra admin center [Will be deprecated in March 2024]</b></summary>
+
+>[!IMPORTANT]
+>After March 14th, 2024 this setting will be deprecated and longer available for adjustments. At that time, please utilize the PowerShell cmndlets listed below to adjust your Team RSC setttings.
 
 You can enable or disable group owner consent directly within the Microsoft Entra admin center:
 
@@ -371,7 +377,10 @@ In addition, you can enable or disable group owner consent using PowerShell. Fol
 <br>
 <details>
 
-<summary><b>Configure chat owner consent settings for RSC in a chat using the Graph APIs</b></summary>
+<summary><b>Configure chat owner consent settings for RSC in a chat using the Graph APIs [Will be deprecated in May 2024]</b></summary>
+
+>[!IMPORTANT]
+>After March 14th, 2024 Microsoft suggests disabling this setting and utlizing the PowerShell cmndlets listed below to manage your Chat RSC settings.
 
 You can enable or disable RSC for chats using Graph API. The property `isChatResourceSpecificConsentEnabled` in [teamsAppSettings](/graph/api/teamsappsettings-update#example-1-enable-installation-of-apps-that-require-resource-specific-consent-in-chats-meetings) governs whether chat RSC is enabled in the tenant.
 
@@ -404,6 +413,32 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 
 > [!NOTE]
 > Admin control is added to allow or block RSC consent settings based on the sensitivity of the data accessed. It isn't based on the single master switch that enables or disables consent settings for app RSC permissions for all apps in the tenant.
+
+</details>
+
+<br>
+
+<b> After March 14th, 2024 </b>
+
+<details>
+
+<summary><b>Configure Team RSC via PowerShell cmndlets</b></summary>
+
+Team owners can authorize applications, such as applications published by third-party vendors, to access your organization's data associated with a group. For example, a Team owner in Microsoft Teams can allow an app to read all Teams messages in the team, or list the basic profile of a Team's members.
+ 
+You can configure which users are allowed to consent to apps accessing their Teams' data, or you can disable the setting for all users.
+
+[PS]
+
+</details>
+
+<details>
+
+<summary><b>Configure Chat RSC via PowerShell cmndlets</b></summary>
+
+You can enable or disable Chat RSC via PowerShell cmndlets:
+
+[PS]
 
 </details>
 

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -421,6 +421,8 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 
 <b> After March 14th, 2024 </b>
 
+Admins will adjust Team RSC and Chat RSC settings via PowerShell cmndlets. The following states are available when adjusting Team RSC and Chat RSC. Each section below will show examples of how to use these states to adjust your settings.
+
 | PowerShell State | Description |
 | ---- | :----: |
 | ManagedByMicrosoft |  Any RSC enabled app can be consented to by users in your tenant. With these settings enabled, preapproval of RSC permissions is not needed as all RSC enabled apps are approved for use. These settings are managed by Microsoft and may be changed at any time |
@@ -428,17 +430,19 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 | ApprovedForPreApprovedApps |  RSC enabled apps can be consented on an app-by-app basis. Admins can choose which apps are approved for which RSC permissions. |
 | DisabledForAllApps|  No RSC permissions can be consented to by users. In this state, preapproval of RSC permissions will have no effect on users ability to consent to RSC enabled apps |
 
-
-
 <details>
 
 <summary><b>Configure Team RSC via PowerShell cmndlets</b></summary>
 
 Team owners can authorize applications, such as applications published by third-party vendors, to access your organization's data associated with a group. For example, a Team owner in Microsoft Teams can allow an app to read all Teams messages in the team, or list the basic profile of a Team's members.
  
-You can configure which users are allowed to consent to apps accessing their Teams' data, or you can disable the setting for all users.
+You can configure which users are allowed to consent to apps accessing their Teams' data by using the available PowerShell states. ApprovedForAllApps, ApprovedForPreApprovedApps, & DisabledForAllApps
 
-[PS]
+### Disable Team RSC using PowerShell and the DisabledForAllApps state:
+
+```powershell
+Set-MgBetaTeamRscConfiguration -State DisabledForAllApps
+```
 
 </details>
 <br>
@@ -448,7 +452,11 @@ You can configure which users are allowed to consent to apps accessing their Tea
 
 You can enable or disable Chat RSC via PowerShell cmndlets:
 
-[PS]
+### Disable Chat RSC using PowerShell and the DisabledForAllApps state:
+
+```powershell
+Set-MgBetaChatRscConfiguration -State DisabledForAllApps
+```
 
 </details>
 <br>

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -352,7 +352,7 @@ The tenant-level controls of application RSC permissions vary based on the resou
 For delegated permissions, any authorized user can consent to the permissions requested by the app.
 
 >[!WARNING]
->The way you manage settings for application RSC and chat RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify
+>The way you manage settings for team RSC and chat RSC permissions is changing in 2024. Instructions below have been updated to include dates for when new settings will be available for admins to modify
 
 <b> Before March 14th, 2024 </b>
 
@@ -421,11 +421,11 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 
 <b> After March 14th, 2024 </b>
 
-Admins will adjust Team RSC and Chat RSC settings via PowerShell cmndlets. The following states are available when adjusting Team RSC and Chat RSC. Each section below will show examples of how to use these states to adjust your settings.
+Admins will adjust Team RSC and Chat RSC settings via PowerShell cmndlets. Below are the available states for the PowerShell settings. Each section below will show examples of how to use these states to adjust your settings.
 
 | PowerShell State | Description |
 | ---- | :----: |
-| ManagedByMicrosoft |  Any RSC enabled app can be consented to by users in your tenant. With these settings enabled, preapproval of RSC permissions is not needed as all RSC enabled apps are approved for use. These settings are managed by Microsoft and may be changed at any time |
+| ManagedByMicrosoft |  This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsoft's discretion |
 | ApprovedForAllApps |  Any RSC enabled app can be consented to by users in your tenant. With these settings enabled, preapproval of RSC permissions is not needed as all RSC enabled apps are approved for use |
 | ApprovedForPreApprovedApps |  RSC enabled apps can be consented on an app-by-app basis. Admins can choose which apps are approved for which RSC permissions. |
 | DisabledForAllApps|  No RSC permissions can be consented to by users. In this state, preapproval of RSC permissions will have no effect on users ability to consent to RSC enabled apps |
@@ -433,12 +433,13 @@ Admins will adjust Team RSC and Chat RSC settings via PowerShell cmndlets. The f
 <details>
 
 <summary><b>Configure Team RSC via PowerShell cmndlets</b></summary>
+<br>
 
-Team owners can authorize applications, such as applications published by third-party vendors, to access your organization's data associated with a group. For example, a Team owner in Microsoft Teams can allow an app to read all Teams messages in the team, or list the basic profile of a Team's members.
- 
 You can configure which users are allowed to consent to apps accessing their Teams' data by using the available PowerShell states. ApprovedForAllApps, ApprovedForPreApprovedApps, & DisabledForAllApps
+<br>
 
-### Disable Team RSC using PowerShell and the DisabledForAllApps state:
+Below is an example of how to disable Team RSC for all apps: 
+<br>
 
 ```powershell
 Set-MgBetaTeamRscConfiguration -State DisabledForAllApps
@@ -449,10 +450,13 @@ Set-MgBetaTeamRscConfiguration -State DisabledForAllApps
 <details>
 
 <summary><b>Configure Chat RSC via PowerShell cmndlets</b></summary>
+<br>
 
-You can enable or disable Chat RSC via PowerShell cmndlets:
+You can configure which users are allowed to consent to apps accessing their Chats' data by using the available PowerShell states. ApprovedForAllApps, ApprovedForPreApprovedApps, & DisabledForAllApps
+<br>
 
-### Disable Chat RSC using PowerShell and the DisabledForAllApps state:
+Below is an example of how to disable Chat RSC for all apps: 
+<br>
 
 ```powershell
 Set-MgBetaChatRscConfiguration -State DisabledForAllApps

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -428,7 +428,7 @@ The default value of the property `isUserPersonalScopeResourceSpecificConsentEna
 Admins will adjust Team RSC and Chat RSC settings via PowerShell cmdlets. Below are the available states for the PowerShell settings. Each section below will show examples of how to use these states to adjust your settings.
 
 | PowerShell State | Description |
-| ---- | :---- |
+| ---- | ---- |
 | ManagedByMicrosoft | This is the default state for all tenants, it allows Chat RSC and Team RSC permissions to be consented for all users, but can be changed at any time at Microsofts discretion |
 | EnabledForAllApps | Any app requesting RSC permissions can be consented to by users (resource owners) in your tenant |
 | DisabledForAllApps | No RSC permissions can be consented to by users. |


### PR DESCRIPTION
Added a section outlining the retirement of Group Owner Consent in Entra settings and the addition of Team and Chat RSC management via PowerShell cmdnlets. Added new section outlining the possible states of the PowerShell RSC settings, and added dates for retirement of the older Group Owner Consent and ChatRSC settings