### PR TITLE
[Doc Improvement] appDeeplinks property in manifest

### DIFF
--- a/msteams-platform/resources/schema/manifest-schema-dev-preview.md
+++ b/msteams-platform/resources/schema/manifest-schema-dev-preview.md
@@ -955,6 +955,7 @@ The `extensions` property specifies Outlook Add-ins within an app manifest and s
 |`autoRunEvents`| Array | | | Defines the event-based activation extension point. |
 |`alternates`| Array | | | Specifies the relationship to alternate existing Microsoft 365 solutions. It's used to hide or prioritize add-ins from the same publisher with overlapping functionality. |
 |`audienceClaimUrl`| String | 2048 characters | | Specifies the URL for your extension and is used to validate Exchange user identity tokens. For more information, see [inside the Exchange identity token](/office/dev/add-ins/outlook/inside-the-identity-token)|
+|`appDeeplinks`| Array | | | Do not use. For Microsoft internal use only. |
 
 For more information, see [Office Add-ins manifest for Microsoft 365](/office/dev/add-ins/develop/unified-manifest-overview).
 


### PR DESCRIPTION
This PR is kind of urgent. The appDeeplinks property is already in the preview manifest but there's nothing in the Intellisense or the schema that tells readers that they must not use it. 