### PR TITLE
Post-publish fixes to localization schema reference

### DIFF
--- a/msteams-platform/resources/schema/localization-schema.md
+++ b/msteams-platform/resources/schema/localization-schema.md
@@ -55,7 +55,7 @@ The schema defines the following properties:
 |`composeExtensions\\[0\\]\\.commands\\[[0-9]\\]\\.taskInfo\\.title`|String|64|Replaces the corresponding strings from the app manifest with the value provided here.||
 |`activities.activityTypes\\[\\b([0-9]&#124;[1-8][0-9]&#124;9[0-9]&#124;1[01][0-9]&#124;12[0-7])\\b]\\.description`|String|128|A brief description of the notification.||
 |`activities.activityTypes\\[\\b([0-9]&#124;[1-8][0-9]&#124;9[0-9]&#124;1[01][0-9]&#124;12[0-7])\\b]\\.templateText`|String|128|Ex: "{actor} created task {taskId} for you".||
-|`\\[\\[[a-zA-Z_][a-zA-Z0-9_]*\\]\\]`|String|4000| Represents custom tokenized keys, for example with [localized Copilot agents](/microsoft-365-copilot/extensibility/agents-are-apps#localizing-your-agent).||
+|`localizationKeys\\[\\[[a-zA-Z_][a-zA-Z0-9_]*\\]\\]`|String|4000| Represents custom tokenized keys, for example with [localized Copilot agents](/microsoft-365-copilot/extensibility/agents-are-apps#localizing-your-agent).||
 |`meetingExtensionDefinition.scenes\\[[0-9]\\]\\.name`|String|128|Replaces the corresponding strings from the app manifest. ||
 |`extensions\\[[0]\\]\\.audienceClaimUrl$`|String|2048|Replaces the corresponding strings from the app manifest with the value provided here.||
 |`extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.label`|String|64|Replaces the corresponding strings from the app manifest with the value provided here.||

--- a/msteams-platform/resources/schema/localization-schema.md
+++ b/msteams-platform/resources/schema/localization-schema.md
@@ -53,8 +53,8 @@ The schema defines the following properties:
 |`composeExtensions\\[0\\]\\.commands\\[[0-9]\\]\\.parameters\\[[0-4]\\]\\.choices\\[[0-9]\\]\\.title`|String|128|Replaces the corresponding strings from the app manifest with the value provided here.||
 |`composeExtensions\\[0\\]\\.commands\\[[0-9]\\]\\.samplePrompts\\[[0-4]\\]\\.text`|String|128|Content for the sample prompt.||
 |`composeExtensions\\[0\\]\\.commands\\[[0-9]\\]\\.taskInfo\\.title`|String|64|Replaces the corresponding strings from the app manifest with the value provided here.||
-|`activities.activityTypes\\[\\b([0-9]|[1-8][0-9]|9[0-9]|1[01][0-9]|12[0-7])\\b]\\.description`|String|128|A brief description of the notification.||
-|`activities.activityTypes\\[\\b([0-9]|[1-8][0-9]|9[0-9]|1[01][0-9]|12[0-7])\\b]\\.templateText`|String|128|Ex: "{actor} created task {taskId} for you".||
+|`activities.activityTypes\\[\\b([0-9]&#124;[1-8][0-9]&#124;9[0-9]&#124;1[01][0-9]&#124;12[0-7])\\b]\\.description`|String|128|A brief description of the notification.||
+|`activities.activityTypes\\[\\b([0-9]&#124;[1-8][0-9]&#124;9[0-9]&#124;1[01][0-9]&#124;12[0-7])\\b]\\.templateText`|String|128|Ex: "{actor} created task {taskId} for you".||
 |`\\[\\[[a-zA-Z_][a-zA-Z0-9_]*\\]\\]`|String|4000| Represents custom tokenized keys, for example with [localized Copilot agents](/microsoft-365-copilot/extensibility/agents-are-apps#localizing-your-agent).||
 |`meetingExtensionDefinition.scenes\\[[0-9]\\]\\.name`|String|128|Replaces the corresponding strings from the app manifest. ||
 |`extensions\\[[0]\\]\\.audienceClaimUrl$`|String|2048|Replaces the corresponding strings from the app manifest with the value provided here.||

--- a/msteams-platform/resources/schema/localization-schema.md
+++ b/msteams-platform/resources/schema/localization-schema.md
@@ -53,8 +53,8 @@ The schema defines the following properties:
 |`composeExtensions\\[0\\]\\.commands\\[[0-9]\\]\\.parameters\\[[0-4]\\]\\.choices\\[[0-9]\\]\\.title`|String|128|Replaces the corresponding strings from the app manifest with the value provided here.||
 |`composeExtensions\\[0\\]\\.commands\\[[0-9]\\]\\.samplePrompts\\[[0-4]\\]\\.text`|String|128|Content for the sample prompt.||
 |`composeExtensions\\[0\\]\\.commands\\[[0-9]\\]\\.taskInfo\\.title`|String|64|Replaces the corresponding strings from the app manifest with the value provided here.||
-|`activities.activityTypes\\[\\b([0-9]&#124;[1-8][0-9]&#124;9[0-9]&#124;1[01][0-9]&#124;12[0-7])\\b]\\.description`|String|128|A brief description of the notification.||
-|`activities.activityTypes\\[\\b([0-9]&#124;[1-8][0-9]&#124;9[0-9]&#124;1[01][0-9]&#124;12[0-7])\\b]\\.templateText`|String|128|Ex: "{actor} created task {taskId} for you".||
+|`activities.activityTypes\\[\\b([0-9]|[1-8][0-9]|9[0-9]&|1[01][0-9]&|12[0-7])\\b]\\.description`|String|128|A brief description of the notification.||
+|`activities.activityTypes\\[\\b([0-9]|[1-8][0-9]|9[0-9]&|1[01][0-9]&|12[0-7])\\b]\\.templateText`|String|128|Ex: "{actor} created task {taskId} for you".||
 |`localizationKeys\\[\\[[a-zA-Z_][a-zA-Z0-9_]*\\]\\]`|String|4000| Represents custom tokenized keys, for example with [localized Copilot agents](/microsoft-365-copilot/extensibility/agents-are-apps#localizing-your-agent).||
 |`meetingExtensionDefinition.scenes\\[[0-9]\\]\\.name`|String|128|Replaces the corresponding strings from the app manifest. ||
 |`extensions\\[[0]\\]\\.audienceClaimUrl$`|String|2048|Replaces the corresponding strings from the app manifest with the value provided here.||


### PR DESCRIPTION
Fixing some errors from last week's 1.19 GA publish:

- Add localizationKeys property (see [schema](https://github.com/microsoft/json-schemas/blob/main/teams/v1.19/MicrosoftTeams.Localization.schema.json#L26-L30))