### PR TITLE
Added note regarding authentication.notifySuccess result parameter

### DIFF
--- a/msteams-platform/messaging-extensions/how-to/add-authentication.md
+++ b/msteams-platform/messaging-extensions/how-to/add-authentication.md
@@ -82,6 +82,10 @@ When the sign in request completes and redirects back to your page, it must perf
 1. Generate a security code, a random number. You must cache this code on your service, with the credentials obtained through the sign-in flow, such as OAuth 2.0 tokens.
 1. Call `authentication.notifySuccess` and pass the security code.
 
+    > [!IMPORTANT]
+    >
+    > Be aware that there are security considerations for the `notifySuccess()` **result** parameter. For additional information, refer to the remarks section of the TeamsJS reference documentation for the [notifySuccess()](/javascript/api/%40microsoft/teams-js/authentication#@microsoft-teams-js-authentication-notifysuccess) function.
+
 At this point, the window closes and the control is passed to the Teams client. The client now reissues the original user query, along with the security code in the `state` property. Your code can use the security code to look up the credentials stored earlier to complete the authentication sequence and then complete the user request.
 
 #### Reissued request example

--- a/msteams-platform/tabs/how-to/authentication/auth-flow-tab.md
+++ b/msteams-platform/tabs/how-to/authentication/auth-flow-tab.md
@@ -41,8 +41,13 @@ Similar to other application auth flows in Teams, the start page must be on a do
 5. On the provider's site, the user sign in and grants access to the tab.
 6. The provider takes the user to the tab's OAuth 2.0 redirect page with an access token.
 7. The tab checks that the returned `state` value matches what was saved earlier, and calls `authentication.notifySuccess()`, which in turn calls the success handler (`.then()`) for the promise-based `authenticate()` method from step 3.
-8. Teams closes the pop-up window.
-9. The tab either displays configuration UI, refreshes, or reloads the tabs content, depending on where the user started from.
+
+    > [!IMPORTANT]
+    >
+    > Be aware that there are security considerations for the `notifySuccess()` **result** parameter. For additional information, refer to the remarks section of the TeamsJS reference documentation for the [notifySuccess()](/javascript/api/%40microsoft/teams-js/authentication#@microsoft-teams-js-authentication-notifysuccess) function.
+
+1. Teams closes the pop-up window.
+1. The tab either displays configuration UI, refreshes, or reloads the tabs content, depending on where the user started from.
 
 > [!NOTE]
 >


### PR DESCRIPTION
Guidance was added to the TeamsJS reference for authentication.notifySuccess regarding the use of the result parameter. Adding a note to the relevant docs calling that out, along with a link to the function in the reference.