### PR TITLE
Add link to Teams AI V2 docs from V1 docs

### DIFF
--- a/msteams-platform/bots/how-to/teams-conversational-ai/teams-conversation-ai-overview.md
+++ b/msteams-platform/bots/how-to/teams-conversational-ai/teams-conversation-ai-overview.md
@@ -11,6 +11,9 @@ ms.owner: angovil
 
 # Teams AI library
 
+> [!IMPORTANT]
+> Teams AI v2 is now available in preview. Learn more about the new and improved developer experience, MCP support, and more [here](https://aka.ms/teamsaiv2).
+
 Teams AI library is a Teams-centric interface for integrating GPT-based language models and user intent engines. It simplifies the development process by reducing the need to write and maintain complex conversational bot logic.
 
 :::image type="content" border="false" source="../../../assets/images/bots/teams-ai-library.png" alt-text="Visual representation of a user input and a bot response."lightbox="../../../assets/images/bots/teams-ai-library.png":::
@@ -27,10 +30,10 @@ You can rely on the built-in conversational bot capabilities in Teams (such as P
 
 You can leverage Teams AI library to:
 
-* Use prebuilt templates to add Teams app capabilities.
-* Use techniques like prompt engineering to add ChatGPT-like conversational experiences to your bot and built-in safety features, like moderation, to help ensure your bot always responds appropriately.
-* Use the library's planning engine that allows the model to identify the user's intent and then map that intent to actions that you implement.
-* Add support for any LLM of your choice without changing the bot logic.
+- Use prebuilt templates to add Teams app capabilities.
+- Use techniques like prompt engineering to add ChatGPT-like conversational experiences to your bot and built-in safety features, like moderation, to help ensure your bot always responds appropriately.
+- Use the library's planning engine that allows the model to identify the user's intent and then map that intent to actions that you implement.
+- Add support for any LLM of your choice without changing the bot logic.
 
 Teams AI library supports both JavaScript and C#. It allows you to harness AI capabilities to build intelligent, user-friendly applications for Microsoft Teams. The library provides the flexibility to create AI-powered experiences using the tools and languages that best suit your project needs and ensures the best possible outcomes for your Teams users.
 
@@ -43,129 +46,130 @@ As a developer, you might want to build an intelligent lightbot that controls th
 Following are some key features and their benefits:
 
 :::row:::
-    :::column span="":::
-        **Localization**
-    :::column-end:::
-    :::column span="2":::
-        Teams AI library uses OpenAI's GPT model for localization. User inputs in any language are translated to intents, entities, and actions. This approach eliminates the need for maintaining localization records.
-    :::column-end:::
+:::column span="":::
+**Localization**
+:::column-end:::
+:::column span="2":::
+Teams AI library uses OpenAI's GPT model for localization. User inputs in any language are translated to intents, entities, and actions. This approach eliminates the need for maintaining localization records.
+:::column-end:::
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **LLM modularity**
-    :::column-end:::
-    :::column span="2":::
-        An LLM generates coherent and diverse natural language text using latent variables. Teams AI library uses OpenAI's GPT model but it allows you to swap it with any LLM without changing the bot logic. This means you can keep your app's content outside the public domain and confined to your preferred LLM model.
-    :::column-end:::
+:::column span="":::
+**LLM modularity**
+:::column-end:::
+:::column span="2":::
+An LLM generates coherent and diverse natural language text using latent variables. Teams AI library uses OpenAI's GPT model but it allows you to swap it with any LLM without changing the bot logic. This means you can keep your app's content outside the public domain and confined to your preferred LLM model.
+:::column-end:::
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Responsible AI**
-    :::column-end:::
-    :::column span="2":::
-        Teams AI library helps build conversational apps with moderation hooks, conversation sweeping, and feedback loops. It supports both low-code and complex scenarios. The library extends capabilities with AI constructs for natural language modeling, user intent, personalization, and automated context-aware conversations.
-    :::column-end:::
+:::column span="":::
+**Responsible AI**
+:::column-end:::
+:::column span="2":::
+Teams AI library helps build conversational apps with moderation hooks, conversation sweeping, and feedback loops. It supports both low-code and complex scenarios. The library extends capabilities with AI constructs for natural language modeling, user intent, personalization, and automated context-aware conversations.
+:::column-end:::
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Predictive engine for mapping intents to actions**
-    :::column-end:::
-    :::column span="2":::
-        A simple interface for actions and predictions allows a bot to react when needed. Ambient presence lets a bot learn intent, use business logic prompts, and generate responses. For example, if a user is out of office and needs to summarize a thread, Teams AI library:
-        
+:::column span="":::
+**Predictive engine for mapping intents to actions**
+:::column-end:::
+:::column span="2":::
+A simple interface for actions and predictions allows a bot to react when needed. Ambient presence lets a bot learn intent, use business logic prompts, and generate responses. For example, if a user is out of office and needs to summarize a thread, Teams AI library:
+
             1. Understands the intent as summarization.
             1. Uses prompts to make summarizations over time, focused on the user’s interactions.
             1. Provides actions to summarize the chat content.
     :::column-end:::
+
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Action Planner**
-    :::column-end:::
-    :::column span="2":::
-        Action Planner is the main component that calls your LLM and includes several features to enhance and customize your model. Model plugins simplify configuring your selected LLM to the planner and ship with an OpenAIModel that supports both OpenAI and Azure OpenAI LLMs. You can add more plugins for other models like Llama-2 to choose the best model for your use case. An internal feedback loop increases reliability by fixing subpar responses from the LLM.
-    :::column-end:::
+:::column span="":::
+**Action Planner**
+:::column-end:::
+:::column span="2":::
+Action Planner is the main component that calls your LLM and includes several features to enhance and customize your model. Model plugins simplify configuring your selected LLM to the planner and ship with an OpenAIModel that supports both OpenAI and Azure OpenAI LLMs. You can add more plugins for other models like Llama-2 to choose the best model for your use case. An internal feedback loop increases reliability by fixing subpar responses from the LLM.
+:::column-end:::
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Assistants API**
-    :::column-end:::
-    :::column span="2":::
-        > [!NOTE]
-        > Teams AI library supports both OpenAI and Azure OpenAI Assistants API in [public developer preview](~/resources/dev-preview/developer-preview-intro.md) to help you get started with building intelligent assistants.
+:::column span="":::
+**Assistants API**
+:::column-end:::
+:::column span="2"::: > [!NOTE] > Teams AI library supports both OpenAI and Azure OpenAI Assistants API in [public developer preview](~/resources/dev-preview/developer-preview-intro.md) to help you get started with building intelligent assistants.
 
         Assistants API allows you to create powerful AI assistants capable of performing tasks that are difficult to code using traditional methods. It provides programmatic access to OpenAI’s GPT system for tasks ranging from chat to image processing, audio processing, and building custom assistants. The API supports natural language interaction to enable the development of assistants that can understand and respond conversationally.
 
         Follow the [quick start guide for Assistants API](assistants-api-quick-start.md) to create an assistant that specializes in mathematics.
     :::column-end:::
+
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Prompt management**
-    :::column-end:::
-    :::column span="2":::
-        Dynamic prompt management lets the bot adjust the size and content of the prompt sent to the LLM based on the available token budget and the data sources or augmentations. This improves the efficiency and accuracy of the prompt by ensuring it doesn't include irrelevant information or exceed the context window.
-    :::column-end:::
+:::column span="":::
+**Prompt management**
+:::column-end:::
+:::column span="2":::
+Dynamic prompt management lets the bot adjust the size and content of the prompt sent to the LLM based on the available token budget and the data sources or augmentations. This improves the efficiency and accuracy of the prompt by ensuring it doesn't include irrelevant information or exceed the context window.
+:::column-end:::
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Augmentation**
-    :::column-end:::
-    :::column span="2":::
-        Enhance your AI model’s responses with Augmentation. Tailor your model using different modes for accuracy and desired outcomes:
+:::column span="":::
+**Augmentation**
+:::column-end:::
+:::column span="2":::
+Enhance your AI model’s responses with Augmentation. Tailor your model using different modes for accuracy and desired outcomes:
 
             * **Retrieval-Augmented Generation (RAG)**: Incorporate real-time, dynamic external data sources for up-to-date, accurate results without re-training.
             * **Monologue**: Create AutoGPT-style agents for multi-step actions with full schema validation and automatic repair.
             * **Sequence**: Enable your AI assistant to return a sequence of actions with schema validation for reliability.
             * **Functions**: Produce structured responses using customizable user-defined functions. The Action Planner assesses and repairs model responses for reliability and consistency.
     :::column-end:::
+
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Vector data sources**
-    :::column-end:::
-    :::column span="2":::
-        Vector databases are designed to store vectors to enable efficient search. They return the most relevant results for a user's query. They allow RAG to use LLMs and custom data or domain-specific information. This involves extracting relevant information from a custom data source and integrating it into the model request through prompt engineering. Before sending a request to the LLM, the user input is transformed into an embedding, and vector search techniques are used to find the most similar embedding in the database.
-    :::column-end:::
+:::column span="":::
+**Vector data sources**
+:::column-end:::
+:::column span="2":::
+Vector databases are designed to store vectors to enable efficient search. They return the most relevant results for a user's query. They allow RAG to use LLMs and custom data or domain-specific information. This involves extracting relevant information from a custom data source and integrating it into the model request through prompt engineering. Before sending a request to the LLM, the user input is transformed into an embedding, and vector search techniques are used to find the most similar embedding in the database.
+:::column-end:::
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Enhanced reasoning**
-    :::column-end:::
-    :::column span="2":::
-        Teams AI library offers an integrated fact-checking system to tackle bot hallucinations. When a user interacts with your AI assistant, it prompts the bot to critically evaluate its potential responses before sending. The bot identifies inaccuracies and corrects its answers, improving accuracy, quality, and contextual relevance. Advanced reasoning ensures that your AI assistant becomes a dependable source of information and judgment, building trust in the product and increasing user engagement.
-    :::column-end:::
+:::column span="":::
+**Enhanced reasoning**
+:::column-end:::
+:::column span="2":::
+Teams AI library offers an integrated fact-checking system to tackle bot hallucinations. When a user interacts with your AI assistant, it prompts the bot to critically evaluate its potential responses before sending. The bot identifies inaccuracies and corrects its answers, improving accuracy, quality, and contextual relevance. Advanced reasoning ensures that your AI assistant becomes a dependable source of information and judgment, building trust in the product and increasing user engagement.
+:::column-end:::
 :::row-end:::
 
 :::row:::
-    :::column span="":::
-        **Feedback loop**
-    :::column-end:::
-    :::column span="2":::
-        The feedback loop allows a bot to validate and correct the output of the language model. It checks the structure and parameters of the plan or monologue that the model returns and provides feedback on errors or missing information. The model attempts to fix its mistakes and return a valid output. This loop improves the reliability and accuracy of the AI system while reducing the chances of hallucinations or invalid actions.
-    :::column-end:::
+:::column span="":::
+**Feedback loop**
+:::column-end:::
+:::column span="2":::
+The feedback loop allows a bot to validate and correct the output of the language model. It checks the structure and parameters of the plan or monologue that the model returns and provides feedback on errors or missing information. The model attempts to fix its mistakes and return a valid output. This loop improves the reliability and accuracy of the AI system while reducing the chances of hallucinations or invalid actions.
+:::column-end:::
 :::row-end:::
 
 ## Updates to Teams AI library
 
 The following table lists the updates to Teams AI library:
 
-| Type                | Description                                                                                                                                                       | .NET | JavaScript | Python |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--: | :--------: | :----: |
-| OpenAIModel         | The OpenAIModel class allows you to call both OpenAI and Azure OpenAI with a single component. New models can be defined for other model types like Llama2.    | ✔️   | ✔️         | ✔️     |
-| Embeddings          | The OpenAIEmbeddings class allows you to generate embeddings using either OpenAI or Azure OpenAI. New embeddings can be defined for things like OSS Embeddings. | ❌   | ✔️         | ✔️     |
-| Prompts             | A new object-based prompt system enables better token management and reduces the likelihood of overflowing the model's context window.                             | ✔️   | ✔️         | ✔️     |
-| Augmentation        | Augmentations simplify prompt engineering tasks by letting the developer add named augmentations to their prompt. Only `functions`, `sequence`, and `monologue` style augmentations are supported. | ✔️   | ✔️         | ✔️     |
-| Data Sources        | A new DataSource plugin makes it easy to add RAG to any prompt. You can register a named data source with the planner and then specify the names of the data sources you wish to augment the prompt. | ❌   | ✔️         | ✔️     |
+| Type         | Description                                                                                                                                                                                          | .NET | JavaScript | Python |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--: | :--------: | :----: |
+| OpenAIModel  | The OpenAIModel class allows you to call both OpenAI and Azure OpenAI with a single component. New models can be defined for other model types like Llama2.                                          |  ✔️  |     ✔️     |   ✔️   |
+| Embeddings   | The OpenAIEmbeddings class allows you to generate embeddings using either OpenAI or Azure OpenAI. New embeddings can be defined for things like OSS Embeddings.                                      |  ❌  |     ✔️     |   ✔️   |
+| Prompts      | A new object-based prompt system enables better token management and reduces the likelihood of overflowing the model's context window.                                                               |  ✔️  |     ✔️     |   ✔️   |
+| Augmentation | Augmentations simplify prompt engineering tasks by letting the developer add named augmentations to their prompt. Only `functions`, `sequence`, and `monologue` style augmentations are supported.   |  ✔️  |     ✔️     |   ✔️   |
+| Data Sources | A new DataSource plugin makes it easy to add RAG to any prompt. You can register a named data source with the planner and then specify the names of the data sources you wish to augment the prompt. |  ❌  |     ✔️     |   ✔️   |
 
 ## Function calls using AI SDK
 
@@ -178,131 +182,131 @@ To use function calling with the Chat Completions API:
 
 1. Set up the planner where the default prompt uses the Tools Augmentation. Update one of the following files of your bot app:
 
-    * For a JavaScript app: Update `index.ts`.
-    * For a C# bot app: Update `Program.cs`.
-    * For a Python app: Update `bot.py`.
+   - For a JavaScript app: Update `index.ts`.
+   - For a C# bot app: Update `Program.cs`.
+   - For a Python app: Update `bot.py`.
 
    The following code snippet shows how to set up the `ToolsAugmentation` class:
 
    # [JavaScript](#tab/javascript)
 
-    ```JavaScript
-    const planner = new ActionPlanner({
-        model,
-        prompts,
-        defaultPrompt: 'tools'
-    });
-    ```
+   ```JavaScript
+   const planner = new ActionPlanner({
+       model,
+       prompts,
+       defaultPrompt: 'tools'
+   });
+   ```
 
    # [C#](#tab/dotnet)
 
-    ```C#
-    ActionPlannerOptions<TurnState> options = new ActionPlannerOptions<TurnState>() 
-    { 
-        Model = model,
-        Prompts = prompts,
-        async (context, state, planner) =>
-        {
-            return await Task.FromResult(prompts.GetPrompt("Tools"));
-        } 
-    }
-    ActionPlanner<TurnState> planner = new ActionPlanner(options)
-    ```
+   ```C#
+   ActionPlannerOptions<TurnState> options = new ActionPlannerOptions<TurnState>()
+   {
+       Model = model,
+       Prompts = prompts,
+       async (context, state, planner) =>
+       {
+           return await Task.FromResult(prompts.GetPrompt("Tools"));
+       }
+   }
+   ActionPlanner<TurnState> planner = new ActionPlanner(options)
+   ```
 
    # [Python](#tab/python)
 
-    ```Python
-    planner = ActionPlanner(ActionPlannerOptions(model=model, prompts=prompts, default_prompt="tools"))
-    ```
+   ```Python
+   planner = ActionPlanner(ActionPlannerOptions(model=model, prompts=prompts, default_prompt="tools"))
+   ```
 
-    ---
+   ***
 
 1. Specify tools augmentation in the `config.json` file.
 
-    ```JSON
-    {
-        "schema": 1.1,
-        "description": "",
-        "type": "",
-        "completion": {
-    +       "tool_choice": "auto",
-    +       "parallel_tool_calls": true,
-        },
-    +    "augmentation": {
-    +        "augmentation_type": "tools"
-    +    }
-    }
-    ```
+   ```JSON
+   {
+       "schema": 1.1,
+       "description": "",
+       "type": "",
+       "completion": {
+   +       "tool_choice": "auto",
+   +       "parallel_tool_calls": true,
+       },
+   +    "augmentation": {
+   +        "augmentation_type": "tools"
+   +    }
+   }
+   ```
 
 1. Specify all your `function definitions` in the `actions.json` file, which is in the `prompts` folder. Ensure that you follow the schema to avoid errors when the action is called by the LLM.
 
-    ```JSON
-    [{
-        "name": "CreateList",
-        "description": "Creates a list"
-    }]
-    ```
+   ```JSON
+   [{
+       "name": "CreateList",
+       "description": "Creates a list"
+   }]
+   ```
 
 1. Register your `handlers` in your `application` class.
 
-    * Each handler is a callback function that runs when a specific event happens. The function call handler executes code in response to the event.
-    * The function call must return a string as the output of the function call.
-    * When the model requests to invoke any functions, these are mapped to `DO` commands within a `Plan` and are invoked in the AI class `run` function. The outputs are then returned to the model with tool call IDs to show that the tools were used.
+   - Each handler is a callback function that runs when a specific event happens. The function call handler executes code in response to the event.
+   - The function call must return a string as the output of the function call.
+   - When the model requests to invoke any functions, these are mapped to `DO` commands within a `Plan` and are invoked in the AI class `run` function. The outputs are then returned to the model with tool call IDs to show that the tools were used.
 
    The following code snippet shows how to register `handlers`:
 
    # [JavaScript](#tab/javascript1)
 
-    ```JavaScript
-    app.ai.action("createList", async (context: TurnContext, state: ApplicationTurnState, parameters: ListAndItems) => {
-    // Ex. create a list with name "Grocery Shopping".
-    ensureListExists(state, parameters.list);
-    return `list created and items added. think about your next action`;
-    });
-    ```
+   ```JavaScript
+   app.ai.action("createList", async (context: TurnContext, state: ApplicationTurnState, parameters: ListAndItems) => {
+   // Ex. create a list with name "Grocery Shopping".
+   ensureListExists(state, parameters.list);
+   return `list created and items added. think about your next action`;
+   });
+   ```
 
    # [C#](#tab/dotnet1)
 
-    ```C#
-    [Action("CreateList")]
-    public string CreateList([ActionTurnState] ListState turnState, [ActionParameters] Dictionary<string, object> parameters)
-    {
-        ArgumentNullException.ThrowIfNull(turnState);
-        ArgumentNullException.ThrowIfNull(parameters);
+   ```C#
+   [Action("CreateList")]
+   public string CreateList([ActionTurnState] ListState turnState, [ActionParameters] Dictionary<string, object> parameters)
+   {
+       ArgumentNullException.ThrowIfNull(turnState);
+       ArgumentNullException.ThrowIfNull(parameters);
 
-        string listName = GetParameterString(parameters, "list");
+       string listName = GetParameterString(parameters, "list");
 
-        EnsureListExists(turnState, listName);
+       EnsureListExists(turnState, listName);
 
-        return "list created. think about your next action";
-    }
-    ```
+       return "list created. think about your next action";
+   }
+   ```
 
    # [Python](#tab/python1)
 
-    ```Python
-    @app.ai.action("createList")
-    async def create_list(context: ActionTurnContext, state: AppTurnState):
-    ensure_list_exists(state, context.data["list"])
-    # Continues exectuion of next command in the plan.
-    return ""
-    ```
+   ```Python
+   @app.ai.action("createList")
+   async def create_list(context: ActionTurnContext, state: AppTurnState):
+   ensure_list_exists(state, context.data["list"])
+   # Continues exectuion of next command in the plan.
+   return ""
+   ```
 
-    ---
+   ***
 
 ### Enable tool options
 
 You can enable the following tool options:
 
-* **Enable Tool Choice**: Allow the model to select the function it must call by enabling tool selection. In the `config.json` file:
+- **Enable Tool Choice**: Allow the model to select the function it must call by enabling tool selection. In the `config.json` file:
 
-  * Set `tool_choice` as `required` to mandate the model to always call at least one function.
-  * Set `tool_choice` to a specific function using its definition for using that function.
-  * Set `tool_choice` as `none` to disable the tool.
+  - Set `tool_choice` as `required` to mandate the model to always call at least one function.
+  - Set `tool_choice` to a specific function using its definition for using that function.
+  - Set `tool_choice` as `none` to disable the tool.
 
   The default value of `tool_choice`is `auto`. It enables the model to select the functions that it must call.
 
-* **Toggle Parallel Tool Calls**: Executing tools in parallel is faster and reduces the number of back-and-forth calls to the API. In the `config.json` file, you can set `parallel_tool_calls` to `true` or `false`. By default, the `parallel_tool_calls` parameter is set to `true`.
+- **Toggle Parallel Tool Calls**: Executing tools in parallel is faster and reduces the number of back-and-forth calls to the API. In the `config.json` file, you can set `parallel_tool_calls` to `true` or `false`. By default, the `parallel_tool_calls` parameter is set to `true`.
 
 The following code snippet shows how to enable tool choice and to toggle parallel tool calls:
 
@@ -329,27 +333,26 @@ The following code snippet shows how to enable tool choice and to toggle paralle
 
 Below is a table listing sample projects demonstrating various features of Teams AI library. These samples cover different scenarios from simple echo bots to advanced conversational assistants, helping you see the library in action across multiple languages.
 
-| Sample name                           | Description                                                                                                                                                     | .NET                                                                                         | Node.js                                                                                                     | Python                                                                                                       |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Echo bot                              | This sample shows how to incorporate a conversational flow into a Microsoft Teams application using Bot Framework and Teams AI library.                        | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/01.messaging.echoBot)  | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/01.getting-started/a.echoBot)              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/01.messaging.a.echoBot)                |
-| Search command message extension      | This sample shows how to incorporate a basic Message Extension app into a Microsoft Teams application using Bot Framework and Teams AI library.               | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/02.messageExtensions.a.searchCommand) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/02.teams-features/a.messageExtensions.searchCommand) | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/02.messageExtensions.a.searchCommand)    |
-| Typeahead bot                         | This sample shows how to incorporate the typeahead search functionality in Adaptive Cards into a Microsoft Teams application using Bot Framework and Teams AI library. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/03.adaptiveCards.a.typeAheadBot) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot) | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/03.adaptiveCards.a.typeAheadBot)       |
-| Conversational bot with AI: Teams chef | This sample shows how to incorporate conversational bot behavior into Microsoft Teams. The bot is built to allow GPT to facilitate the conversation on its behalf, using only a natural language prompt file to guide it. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.a.teamsChefBot)     | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/a.teamsChefBot)                 |                                                                                                              |
-| Message extensions: GPT-ME             | This sample is a message extension for Microsoft Teams that uses the text-davinci-003 model to help users generate and update posts.                           | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.b.messageExtensions.gptME) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/b.AI-messageExtensions)         | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.b.messageExtensions.AI-ME)         |
-| Light bot                             | This sample illustrates more complex conversational bot behavior in Microsoft Teams. The bot allows GPT to facilitate the conversation on its behalf with manually defined responses, mapping user intents to user-defined actions. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.c.actionMapping.lightBot) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/c.actionMapping-lightBot)       | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.c.actionMapping.lightBot)        |
-| List bot                              | This sample shows how to incorporate conversational bot behavior into Microsoft Teams. The bot harnesses the power of AI to simplify your workflow, bring order to your daily tasks, and showcases action chaining capabilities. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.d.chainedActions.listBot) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/d.chainedActions-listBot)        | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.d.chainedActions.listBot)        |
-| DevOps bot                            | This sample shows how to incorporate conversational bot behavior in Microsoft Teams. The bot uses the gpt-3.5-turbo model to chat with Teams users and perform DevOps actions such as create, update, triage, and summarize work items. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.e.chainedActions.devOpsBot) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/b.devOpsBot)                        | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.e.chainedActions.devOpsBot)        |
-| Twenty questions                      | This sample showcases the incredible capabilities of language models and the concept of user intent. Challenge your skills as a human player and try to guess a secret within 20 questions, while the AI-powered bot answers your queries about the secret. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.e.twentyQuestions)       | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/a.twentyQuestions)              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.a.twentyQuestions)                 |
-| Math tutor assistant                  | This example shows how to create a conversational experience using OpenAI's Assistants APIs. It uses OpenAI's Code Interpreter tool to create an assistant that's an expert on math. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/06.assistants.a.mathBot)     | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/d.assistants-mathBot)              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/06.assistants.a.mathBot)                |
-| Food ordering assistant               | This example shows how to create a conversational assistant that uses tools to call actions in your bot's code. It's a food ordering assistant for a fictional restaurant called The Pub and is capable of complex interactions with the user as it takes their order. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/06.assistants.b.orderBot)    | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/e.assistants-orderBot)              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/06.assistants.b.orderBot)               |
+| Sample name                            | Description                                                                                                                                                                                                                                                            | .NET                                                                                                        | Node.js                                                                                                                | Python                                                                                                      |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Echo bot                               | This sample shows how to incorporate a conversational flow into a Microsoft Teams application using Bot Framework and Teams AI library.                                                                                                                                | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/01.messaging.echoBot)                 | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/01.getting-started/a.echoBot)                        | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/01.messaging.a.echoBot)               |
+| Search command message extension       | This sample shows how to incorporate a basic Message Extension app into a Microsoft Teams application using Bot Framework and Teams AI library.                                                                                                                        | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/02.messageExtensions.a.searchCommand) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/02.teams-features/a.messageExtensions.searchCommand) | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/02.messageExtensions.a.searchCommand) |
+| Typeahead bot                          | This sample shows how to incorporate the typeahead search functionality in Adaptive Cards into a Microsoft Teams application using Bot Framework and Teams AI library.                                                                                                 | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/03.adaptiveCards.a.typeAheadBot)      | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot)      | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/03.adaptiveCards.a.typeAheadBot)      |
+| Conversational bot with AI: Teams chef | This sample shows how to incorporate conversational bot behavior into Microsoft Teams. The bot is built to allow GPT to facilitate the conversation on its behalf, using only a natural language prompt file to guide it.                                              | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.a.teamsChefBot)                 | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/a.teamsChefBot)                           |                                                                                                             |
+| Message extensions: GPT-ME             | This sample is a message extension for Microsoft Teams that uses the text-davinci-003 model to help users generate and update posts.                                                                                                                                   | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.b.messageExtensions.gptME)      | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/b.AI-messageExtensions)               | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.b.messageExtensions.AI-ME)      |
+| Light bot                              | This sample illustrates more complex conversational bot behavior in Microsoft Teams. The bot allows GPT to facilitate the conversation on its behalf with manually defined responses, mapping user intents to user-defined actions.                                    | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.c.actionMapping.lightBot)       | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/c.actionMapping-lightBot)             | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.c.actionMapping.lightBot)       |
+| List bot                               | This sample shows how to incorporate conversational bot behavior into Microsoft Teams. The bot harnesses the power of AI to simplify your workflow, bring order to your daily tasks, and showcases action chaining capabilities.                                       | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.d.chainedActions.listBot)       | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/d.chainedActions-listBot)             | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.d.chainedActions.listBot)       |
+| DevOps bot                             | This sample shows how to incorporate conversational bot behavior in Microsoft Teams. The bot uses the gpt-3.5-turbo model to chat with Teams users and perform DevOps actions such as create, update, triage, and summarize work items.                                | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.e.chainedActions.devOpsBot)     | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/b.devOpsBot)                              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.e.chainedActions.devOpsBot)     |
+| Twenty questions                       | This sample showcases the incredible capabilities of language models and the concept of user intent. Challenge your skills as a human player and try to guess a secret within 20 questions, while the AI-powered bot answers your queries about the secret.            | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.e.twentyQuestions)                 | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/a.twentyQuestions)                    | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.a.twentyQuestions)              |
+| Math tutor assistant                   | This example shows how to create a conversational experience using OpenAI's Assistants APIs. It uses OpenAI's Code Interpreter tool to create an assistant that's an expert on math.                                                                                   | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/06.assistants.a.mathBot)              | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/d.assistants-mathBot)                     | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/06.assistants.a.mathBot)              |
+| Food ordering assistant                | This example shows how to create a conversational assistant that uses tools to call actions in your bot's code. It's a food ordering assistant for a fictional restaurant called The Pub and is capable of complex interactions with the user as it takes their order. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/06.assistants.b.orderBot)             | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/e.assistants-orderBot)                    | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/06.assistants.b.orderBot)             |
 
 ## Next step
 
-> [!div class="nextstepaction"]
-> [Teams AI library quick start guide](conversation-ai-quick-start.md)
+> [!div class="nextstepaction"] > [Teams AI library quick start guide](conversation-ai-quick-start.md)
 
 ## See also
 
-* [Teams AI library v2 (preview)](/microsoftteams/platform/teams-ai-library/welcome/overview)
-* [Copilot handoff](../conversations/bot-copilot-handoff.md)
-* [Teams AI library FAQs](../../../teams-faq.md#teams-ai-library)
+- [Teams AI library v2 (preview)](/microsoftteams/platform/teams-ai-library/welcome/overview)
+- [Copilot handoff](../conversations/bot-copilot-handoff.md)
+- [Teams AI library FAQs](../../../teams-faq.md#teams-ai-library)

--- a/msteams-platform/bots/how-to/teams-conversational-ai/teams-conversation-ai-overview.md
+++ b/msteams-platform/bots/how-to/teams-conversational-ai/teams-conversation-ai-overview.md
@@ -12,7 +12,7 @@ ms.owner: angovil
 # Teams AI library
 
 > [!IMPORTANT]
-> Teams AI v2 is now available in preview. Learn more about the new and improved developer experience, MCP support, and more [here](https://aka.ms/teamsaiv2).
+> [Teams AI library v2](/microsoftteams/platform/teams-ai-library/) is available in developer preview. Learn more about the new and improved developer experience, MCP support, and more.
 
 Teams AI library is a Teams-centric interface for integrating GPT-based language models and user intent engines. It simplifies the development process by reducing the need to write and maintain complex conversational bot logic.
 
@@ -78,7 +78,7 @@ Following are some key features and their benefits:
     :::column-end:::
     :::column span="2":::
         A simple interface for actions and predictions allows a bot to react when needed. Ambient presence lets a bot learn intent, use business logic prompts, and generate responses. For example, if a user is out of office and needs to summarize a thread, Teams AI library:
-        
+
             1. Understands the intent as summarization.
             1. Uses prompts to make summarizations over time, focused on the user’s interactions.
             1. Provides actions to summarize the chat content.

--- a/msteams-platform/bots/how-to/teams-conversational-ai/teams-conversation-ai-overview.md
+++ b/msteams-platform/bots/how-to/teams-conversational-ai/teams-conversation-ai-overview.md
@@ -30,10 +30,10 @@ You can rely on the built-in conversational bot capabilities in Teams (such as P
 
 You can leverage Teams AI library to:
 
-- Use prebuilt templates to add Teams app capabilities.
-- Use techniques like prompt engineering to add ChatGPT-like conversational experiences to your bot and built-in safety features, like moderation, to help ensure your bot always responds appropriately.
-- Use the library's planning engine that allows the model to identify the user's intent and then map that intent to actions that you implement.
-- Add support for any LLM of your choice without changing the bot logic.
+* Use prebuilt templates to add Teams app capabilities.
+* Use techniques like prompt engineering to add ChatGPT-like conversational experiences to your bot and built-in safety features, like moderation, to help ensure your bot always responds appropriately.
+* Use the library's planning engine that allows the model to identify the user's intent and then map that intent to actions that you implement.
+* Add support for any LLM of your choice without changing the bot logic.
 
 Teams AI library supports both JavaScript and C#. It allows you to harness AI capabilities to build intelligent, user-friendly applications for Microsoft Teams. The library provides the flexibility to create AI-powered experiences using the tools and languages that best suit your project needs and ensures the best possible outcomes for your Teams users.
 
@@ -46,130 +46,129 @@ As a developer, you might want to build an intelligent lightbot that controls th
 Following are some key features and their benefits:
 
 :::row:::
-:::column span="":::
-**Localization**
-:::column-end:::
-:::column span="2":::
-Teams AI library uses OpenAI's GPT model for localization. User inputs in any language are translated to intents, entities, and actions. This approach eliminates the need for maintaining localization records.
-:::column-end:::
+    :::column span="":::
+        **Localization**
+    :::column-end:::
+    :::column span="2":::
+        Teams AI library uses OpenAI's GPT model for localization. User inputs in any language are translated to intents, entities, and actions. This approach eliminates the need for maintaining localization records.
+    :::column-end:::
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**LLM modularity**
-:::column-end:::
-:::column span="2":::
-An LLM generates coherent and diverse natural language text using latent variables. Teams AI library uses OpenAI's GPT model but it allows you to swap it with any LLM without changing the bot logic. This means you can keep your app's content outside the public domain and confined to your preferred LLM model.
-:::column-end:::
+    :::column span="":::
+        **LLM modularity**
+    :::column-end:::
+    :::column span="2":::
+        An LLM generates coherent and diverse natural language text using latent variables. Teams AI library uses OpenAI's GPT model but it allows you to swap it with any LLM without changing the bot logic. This means you can keep your app's content outside the public domain and confined to your preferred LLM model.
+    :::column-end:::
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Responsible AI**
-:::column-end:::
-:::column span="2":::
-Teams AI library helps build conversational apps with moderation hooks, conversation sweeping, and feedback loops. It supports both low-code and complex scenarios. The library extends capabilities with AI constructs for natural language modeling, user intent, personalization, and automated context-aware conversations.
-:::column-end:::
+    :::column span="":::
+        **Responsible AI**
+    :::column-end:::
+    :::column span="2":::
+        Teams AI library helps build conversational apps with moderation hooks, conversation sweeping, and feedback loops. It supports both low-code and complex scenarios. The library extends capabilities with AI constructs for natural language modeling, user intent, personalization, and automated context-aware conversations.
+    :::column-end:::
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Predictive engine for mapping intents to actions**
-:::column-end:::
-:::column span="2":::
-A simple interface for actions and predictions allows a bot to react when needed. Ambient presence lets a bot learn intent, use business logic prompts, and generate responses. For example, if a user is out of office and needs to summarize a thread, Teams AI library:
-
+    :::column span="":::
+        **Predictive engine for mapping intents to actions**
+    :::column-end:::
+    :::column span="2":::
+        A simple interface for actions and predictions allows a bot to react when needed. Ambient presence lets a bot learn intent, use business logic prompts, and generate responses. For example, if a user is out of office and needs to summarize a thread, Teams AI library:
+        
             1. Understands the intent as summarization.
             1. Uses prompts to make summarizations over time, focused on the user’s interactions.
             1. Provides actions to summarize the chat content.
     :::column-end:::
-
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Action Planner**
-:::column-end:::
-:::column span="2":::
-Action Planner is the main component that calls your LLM and includes several features to enhance and customize your model. Model plugins simplify configuring your selected LLM to the planner and ship with an OpenAIModel that supports both OpenAI and Azure OpenAI LLMs. You can add more plugins for other models like Llama-2 to choose the best model for your use case. An internal feedback loop increases reliability by fixing subpar responses from the LLM.
-:::column-end:::
+    :::column span="":::
+        **Action Planner**
+    :::column-end:::
+    :::column span="2":::
+        Action Planner is the main component that calls your LLM and includes several features to enhance and customize your model. Model plugins simplify configuring your selected LLM to the planner and ship with an OpenAIModel that supports both OpenAI and Azure OpenAI LLMs. You can add more plugins for other models like Llama-2 to choose the best model for your use case. An internal feedback loop increases reliability by fixing subpar responses from the LLM.
+    :::column-end:::
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Assistants API**
-:::column-end:::
-:::column span="2"::: > [!NOTE] > Teams AI library supports both OpenAI and Azure OpenAI Assistants API in [public developer preview](~/resources/dev-preview/developer-preview-intro.md) to help you get started with building intelligent assistants.
+    :::column span="":::
+        **Assistants API**
+    :::column-end:::
+    :::column span="2":::
+        > [!NOTE]
+        > Teams AI library supports both OpenAI and Azure OpenAI Assistants API in [public developer preview](~/resources/dev-preview/developer-preview-intro.md) to help you get started with building intelligent assistants.
 
         Assistants API allows you to create powerful AI assistants capable of performing tasks that are difficult to code using traditional methods. It provides programmatic access to OpenAI’s GPT system for tasks ranging from chat to image processing, audio processing, and building custom assistants. The API supports natural language interaction to enable the development of assistants that can understand and respond conversationally.
 
         Follow the [quick start guide for Assistants API](assistants-api-quick-start.md) to create an assistant that specializes in mathematics.
     :::column-end:::
-
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Prompt management**
-:::column-end:::
-:::column span="2":::
-Dynamic prompt management lets the bot adjust the size and content of the prompt sent to the LLM based on the available token budget and the data sources or augmentations. This improves the efficiency and accuracy of the prompt by ensuring it doesn't include irrelevant information or exceed the context window.
-:::column-end:::
+    :::column span="":::
+        **Prompt management**
+    :::column-end:::
+    :::column span="2":::
+        Dynamic prompt management lets the bot adjust the size and content of the prompt sent to the LLM based on the available token budget and the data sources or augmentations. This improves the efficiency and accuracy of the prompt by ensuring it doesn't include irrelevant information or exceed the context window.
+    :::column-end:::
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Augmentation**
-:::column-end:::
-:::column span="2":::
-Enhance your AI model’s responses with Augmentation. Tailor your model using different modes for accuracy and desired outcomes:
+    :::column span="":::
+        **Augmentation**
+    :::column-end:::
+    :::column span="2":::
+        Enhance your AI model’s responses with Augmentation. Tailor your model using different modes for accuracy and desired outcomes:
 
             * **Retrieval-Augmented Generation (RAG)**: Incorporate real-time, dynamic external data sources for up-to-date, accurate results without re-training.
             * **Monologue**: Create AutoGPT-style agents for multi-step actions with full schema validation and automatic repair.
             * **Sequence**: Enable your AI assistant to return a sequence of actions with schema validation for reliability.
             * **Functions**: Produce structured responses using customizable user-defined functions. The Action Planner assesses and repairs model responses for reliability and consistency.
     :::column-end:::
-
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Vector data sources**
-:::column-end:::
-:::column span="2":::
-Vector databases are designed to store vectors to enable efficient search. They return the most relevant results for a user's query. They allow RAG to use LLMs and custom data or domain-specific information. This involves extracting relevant information from a custom data source and integrating it into the model request through prompt engineering. Before sending a request to the LLM, the user input is transformed into an embedding, and vector search techniques are used to find the most similar embedding in the database.
-:::column-end:::
+    :::column span="":::
+        **Vector data sources**
+    :::column-end:::
+    :::column span="2":::
+        Vector databases are designed to store vectors to enable efficient search. They return the most relevant results for a user's query. They allow RAG to use LLMs and custom data or domain-specific information. This involves extracting relevant information from a custom data source and integrating it into the model request through prompt engineering. Before sending a request to the LLM, the user input is transformed into an embedding, and vector search techniques are used to find the most similar embedding in the database.
+    :::column-end:::
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Enhanced reasoning**
-:::column-end:::
-:::column span="2":::
-Teams AI library offers an integrated fact-checking system to tackle bot hallucinations. When a user interacts with your AI assistant, it prompts the bot to critically evaluate its potential responses before sending. The bot identifies inaccuracies and corrects its answers, improving accuracy, quality, and contextual relevance. Advanced reasoning ensures that your AI assistant becomes a dependable source of information and judgment, building trust in the product and increasing user engagement.
-:::column-end:::
+    :::column span="":::
+        **Enhanced reasoning**
+    :::column-end:::
+    :::column span="2":::
+        Teams AI library offers an integrated fact-checking system to tackle bot hallucinations. When a user interacts with your AI assistant, it prompts the bot to critically evaluate its potential responses before sending. The bot identifies inaccuracies and corrects its answers, improving accuracy, quality, and contextual relevance. Advanced reasoning ensures that your AI assistant becomes a dependable source of information and judgment, building trust in the product and increasing user engagement.
+    :::column-end:::
 :::row-end:::
 
 :::row:::
-:::column span="":::
-**Feedback loop**
-:::column-end:::
-:::column span="2":::
-The feedback loop allows a bot to validate and correct the output of the language model. It checks the structure and parameters of the plan or monologue that the model returns and provides feedback on errors or missing information. The model attempts to fix its mistakes and return a valid output. This loop improves the reliability and accuracy of the AI system while reducing the chances of hallucinations or invalid actions.
-:::column-end:::
+    :::column span="":::
+        **Feedback loop**
+    :::column-end:::
+    :::column span="2":::
+        The feedback loop allows a bot to validate and correct the output of the language model. It checks the structure and parameters of the plan or monologue that the model returns and provides feedback on errors or missing information. The model attempts to fix its mistakes and return a valid output. This loop improves the reliability and accuracy of the AI system while reducing the chances of hallucinations or invalid actions.
+    :::column-end:::
 :::row-end:::
 
 ## Updates to Teams AI library
 
 The following table lists the updates to Teams AI library:
 
-| Type         | Description                                                                                                                                                                                          | .NET | JavaScript | Python |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--: | :--------: | :----: |
-| OpenAIModel  | The OpenAIModel class allows you to call both OpenAI and Azure OpenAI with a single component. New models can be defined for other model types like Llama2.                                          |  ✔️  |     ✔️     |   ✔️   |
-| Embeddings   | The OpenAIEmbeddings class allows you to generate embeddings using either OpenAI or Azure OpenAI. New embeddings can be defined for things like OSS Embeddings.                                      |  ❌  |     ✔️     |   ✔️   |
-| Prompts      | A new object-based prompt system enables better token management and reduces the likelihood of overflowing the model's context window.                                                               |  ✔️  |     ✔️     |   ✔️   |
-| Augmentation | Augmentations simplify prompt engineering tasks by letting the developer add named augmentations to their prompt. Only `functions`, `sequence`, and `monologue` style augmentations are supported.   |  ✔️  |     ✔️     |   ✔️   |
-| Data Sources | A new DataSource plugin makes it easy to add RAG to any prompt. You can register a named data source with the planner and then specify the names of the data sources you wish to augment the prompt. |  ❌  |     ✔️     |   ✔️   |
+| Type                | Description                                                                                                                                                       | .NET | JavaScript | Python |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--: | :--------: | :----: |
+| OpenAIModel         | The OpenAIModel class allows you to call both OpenAI and Azure OpenAI with a single component. New models can be defined for other model types like Llama2.    | ✔️   | ✔️         | ✔️     |
+| Embeddings          | The OpenAIEmbeddings class allows you to generate embeddings using either OpenAI or Azure OpenAI. New embeddings can be defined for things like OSS Embeddings. | ❌   | ✔️         | ✔️     |
+| Prompts             | A new object-based prompt system enables better token management and reduces the likelihood of overflowing the model's context window.                             | ✔️   | ✔️         | ✔️     |
+| Augmentation        | Augmentations simplify prompt engineering tasks by letting the developer add named augmentations to their prompt. Only `functions`, `sequence`, and `monologue` style augmentations are supported. | ✔️   | ✔️         | ✔️     |
+| Data Sources        | A new DataSource plugin makes it easy to add RAG to any prompt. You can register a named data source with the planner and then specify the names of the data sources you wish to augment the prompt. | ❌   | ✔️         | ✔️     |
 
 ## Function calls using AI SDK
 
@@ -182,131 +181,131 @@ To use function calling with the Chat Completions API:
 
 1. Set up the planner where the default prompt uses the Tools Augmentation. Update one of the following files of your bot app:
 
-   - For a JavaScript app: Update `index.ts`.
-   - For a C# bot app: Update `Program.cs`.
-   - For a Python app: Update `bot.py`.
+    * For a JavaScript app: Update `index.ts`.
+    * For a C# bot app: Update `Program.cs`.
+    * For a Python app: Update `bot.py`.
 
    The following code snippet shows how to set up the `ToolsAugmentation` class:
 
    # [JavaScript](#tab/javascript)
 
-   ```JavaScript
-   const planner = new ActionPlanner({
-       model,
-       prompts,
-       defaultPrompt: 'tools'
-   });
-   ```
+    ```JavaScript
+    const planner = new ActionPlanner({
+        model,
+        prompts,
+        defaultPrompt: 'tools'
+    });
+    ```
 
    # [C#](#tab/dotnet)
 
-   ```C#
-   ActionPlannerOptions<TurnState> options = new ActionPlannerOptions<TurnState>()
-   {
-       Model = model,
-       Prompts = prompts,
-       async (context, state, planner) =>
-       {
-           return await Task.FromResult(prompts.GetPrompt("Tools"));
-       }
-   }
-   ActionPlanner<TurnState> planner = new ActionPlanner(options)
-   ```
+    ```C#
+    ActionPlannerOptions<TurnState> options = new ActionPlannerOptions<TurnState>() 
+    { 
+        Model = model,
+        Prompts = prompts,
+        async (context, state, planner) =>
+        {
+            return await Task.FromResult(prompts.GetPrompt("Tools"));
+        } 
+    }
+    ActionPlanner<TurnState> planner = new ActionPlanner(options)
+    ```
 
    # [Python](#tab/python)
 
-   ```Python
-   planner = ActionPlanner(ActionPlannerOptions(model=model, prompts=prompts, default_prompt="tools"))
-   ```
+    ```Python
+    planner = ActionPlanner(ActionPlannerOptions(model=model, prompts=prompts, default_prompt="tools"))
+    ```
 
-   ***
+    ---
 
 1. Specify tools augmentation in the `config.json` file.
 
-   ```JSON
-   {
-       "schema": 1.1,
-       "description": "",
-       "type": "",
-       "completion": {
-   +       "tool_choice": "auto",
-   +       "parallel_tool_calls": true,
-       },
-   +    "augmentation": {
-   +        "augmentation_type": "tools"
-   +    }
-   }
-   ```
+    ```JSON
+    {
+        "schema": 1.1,
+        "description": "",
+        "type": "",
+        "completion": {
+    +       "tool_choice": "auto",
+    +       "parallel_tool_calls": true,
+        },
+    +    "augmentation": {
+    +        "augmentation_type": "tools"
+    +    }
+    }
+    ```
 
 1. Specify all your `function definitions` in the `actions.json` file, which is in the `prompts` folder. Ensure that you follow the schema to avoid errors when the action is called by the LLM.
 
-   ```JSON
-   [{
-       "name": "CreateList",
-       "description": "Creates a list"
-   }]
-   ```
+    ```JSON
+    [{
+        "name": "CreateList",
+        "description": "Creates a list"
+    }]
+    ```
 
 1. Register your `handlers` in your `application` class.
 
-   - Each handler is a callback function that runs when a specific event happens. The function call handler executes code in response to the event.
-   - The function call must return a string as the output of the function call.
-   - When the model requests to invoke any functions, these are mapped to `DO` commands within a `Plan` and are invoked in the AI class `run` function. The outputs are then returned to the model with tool call IDs to show that the tools were used.
+    * Each handler is a callback function that runs when a specific event happens. The function call handler executes code in response to the event.
+    * The function call must return a string as the output of the function call.
+    * When the model requests to invoke any functions, these are mapped to `DO` commands within a `Plan` and are invoked in the AI class `run` function. The outputs are then returned to the model with tool call IDs to show that the tools were used.
 
    The following code snippet shows how to register `handlers`:
 
    # [JavaScript](#tab/javascript1)
 
-   ```JavaScript
-   app.ai.action("createList", async (context: TurnContext, state: ApplicationTurnState, parameters: ListAndItems) => {
-   // Ex. create a list with name "Grocery Shopping".
-   ensureListExists(state, parameters.list);
-   return `list created and items added. think about your next action`;
-   });
-   ```
+    ```JavaScript
+    app.ai.action("createList", async (context: TurnContext, state: ApplicationTurnState, parameters: ListAndItems) => {
+    // Ex. create a list with name "Grocery Shopping".
+    ensureListExists(state, parameters.list);
+    return `list created and items added. think about your next action`;
+    });
+    ```
 
    # [C#](#tab/dotnet1)
 
-   ```C#
-   [Action("CreateList")]
-   public string CreateList([ActionTurnState] ListState turnState, [ActionParameters] Dictionary<string, object> parameters)
-   {
-       ArgumentNullException.ThrowIfNull(turnState);
-       ArgumentNullException.ThrowIfNull(parameters);
+    ```C#
+    [Action("CreateList")]
+    public string CreateList([ActionTurnState] ListState turnState, [ActionParameters] Dictionary<string, object> parameters)
+    {
+        ArgumentNullException.ThrowIfNull(turnState);
+        ArgumentNullException.ThrowIfNull(parameters);
 
-       string listName = GetParameterString(parameters, "list");
+        string listName = GetParameterString(parameters, "list");
 
-       EnsureListExists(turnState, listName);
+        EnsureListExists(turnState, listName);
 
-       return "list created. think about your next action";
-   }
-   ```
+        return "list created. think about your next action";
+    }
+    ```
 
    # [Python](#tab/python1)
 
-   ```Python
-   @app.ai.action("createList")
-   async def create_list(context: ActionTurnContext, state: AppTurnState):
-   ensure_list_exists(state, context.data["list"])
-   # Continues exectuion of next command in the plan.
-   return ""
-   ```
+    ```Python
+    @app.ai.action("createList")
+    async def create_list(context: ActionTurnContext, state: AppTurnState):
+    ensure_list_exists(state, context.data["list"])
+    # Continues exectuion of next command in the plan.
+    return ""
+    ```
 
-   ***
+    ---
 
 ### Enable tool options
 
 You can enable the following tool options:
 
-- **Enable Tool Choice**: Allow the model to select the function it must call by enabling tool selection. In the `config.json` file:
+* **Enable Tool Choice**: Allow the model to select the function it must call by enabling tool selection. In the `config.json` file:
 
-  - Set `tool_choice` as `required` to mandate the model to always call at least one function.
-  - Set `tool_choice` to a specific function using its definition for using that function.
-  - Set `tool_choice` as `none` to disable the tool.
+  * Set `tool_choice` as `required` to mandate the model to always call at least one function.
+  * Set `tool_choice` to a specific function using its definition for using that function.
+  * Set `tool_choice` as `none` to disable the tool.
 
   The default value of `tool_choice`is `auto`. It enables the model to select the functions that it must call.
 
-- **Toggle Parallel Tool Calls**: Executing tools in parallel is faster and reduces the number of back-and-forth calls to the API. In the `config.json` file, you can set `parallel_tool_calls` to `true` or `false`. By default, the `parallel_tool_calls` parameter is set to `true`.
+* **Toggle Parallel Tool Calls**: Executing tools in parallel is faster and reduces the number of back-and-forth calls to the API. In the `config.json` file, you can set `parallel_tool_calls` to `true` or `false`. By default, the `parallel_tool_calls` parameter is set to `true`.
 
 The following code snippet shows how to enable tool choice and to toggle parallel tool calls:
 
@@ -333,26 +332,27 @@ The following code snippet shows how to enable tool choice and to toggle paralle
 
 Below is a table listing sample projects demonstrating various features of Teams AI library. These samples cover different scenarios from simple echo bots to advanced conversational assistants, helping you see the library in action across multiple languages.
 
-| Sample name                            | Description                                                                                                                                                                                                                                                            | .NET                                                                                                        | Node.js                                                                                                                | Python                                                                                                      |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Echo bot                               | This sample shows how to incorporate a conversational flow into a Microsoft Teams application using Bot Framework and Teams AI library.                                                                                                                                | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/01.messaging.echoBot)                 | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/01.getting-started/a.echoBot)                        | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/01.messaging.a.echoBot)               |
-| Search command message extension       | This sample shows how to incorporate a basic Message Extension app into a Microsoft Teams application using Bot Framework and Teams AI library.                                                                                                                        | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/02.messageExtensions.a.searchCommand) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/02.teams-features/a.messageExtensions.searchCommand) | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/02.messageExtensions.a.searchCommand) |
-| Typeahead bot                          | This sample shows how to incorporate the typeahead search functionality in Adaptive Cards into a Microsoft Teams application using Bot Framework and Teams AI library.                                                                                                 | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/03.adaptiveCards.a.typeAheadBot)      | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot)      | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/03.adaptiveCards.a.typeAheadBot)      |
-| Conversational bot with AI: Teams chef | This sample shows how to incorporate conversational bot behavior into Microsoft Teams. The bot is built to allow GPT to facilitate the conversation on its behalf, using only a natural language prompt file to guide it.                                              | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.a.teamsChefBot)                 | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/a.teamsChefBot)                           |                                                                                                             |
-| Message extensions: GPT-ME             | This sample is a message extension for Microsoft Teams that uses the text-davinci-003 model to help users generate and update posts.                                                                                                                                   | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.b.messageExtensions.gptME)      | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/b.AI-messageExtensions)               | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.b.messageExtensions.AI-ME)      |
-| Light bot                              | This sample illustrates more complex conversational bot behavior in Microsoft Teams. The bot allows GPT to facilitate the conversation on its behalf with manually defined responses, mapping user intents to user-defined actions.                                    | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.c.actionMapping.lightBot)       | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/c.actionMapping-lightBot)             | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.c.actionMapping.lightBot)       |
-| List bot                               | This sample shows how to incorporate conversational bot behavior into Microsoft Teams. The bot harnesses the power of AI to simplify your workflow, bring order to your daily tasks, and showcases action chaining capabilities.                                       | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.d.chainedActions.listBot)       | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/d.chainedActions-listBot)             | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.d.chainedActions.listBot)       |
-| DevOps bot                             | This sample shows how to incorporate conversational bot behavior in Microsoft Teams. The bot uses the gpt-3.5-turbo model to chat with Teams users and perform DevOps actions such as create, update, triage, and summarize work items.                                | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.e.chainedActions.devOpsBot)     | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/b.devOpsBot)                              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.e.chainedActions.devOpsBot)     |
-| Twenty questions                       | This sample showcases the incredible capabilities of language models and the concept of user intent. Challenge your skills as a human player and try to guess a secret within 20 questions, while the AI-powered bot answers your queries about the secret.            | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.e.twentyQuestions)                 | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/a.twentyQuestions)                    | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.a.twentyQuestions)              |
-| Math tutor assistant                   | This example shows how to create a conversational experience using OpenAI's Assistants APIs. It uses OpenAI's Code Interpreter tool to create an assistant that's an expert on math.                                                                                   | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/06.assistants.a.mathBot)              | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/d.assistants-mathBot)                     | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/06.assistants.a.mathBot)              |
-| Food ordering assistant                | This example shows how to create a conversational assistant that uses tools to call actions in your bot's code. It's a food ordering assistant for a fictional restaurant called The Pub and is capable of complex interactions with the user as it takes their order. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/06.assistants.b.orderBot)             | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/e.assistants-orderBot)                    | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/06.assistants.b.orderBot)             |
+| Sample name                           | Description                                                                                                                                                     | .NET                                                                                         | Node.js                                                                                                     | Python                                                                                                       |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Echo bot                              | This sample shows how to incorporate a conversational flow into a Microsoft Teams application using Bot Framework and Teams AI library.                        | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/01.messaging.echoBot)  | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/01.getting-started/a.echoBot)              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/01.messaging.a.echoBot)                |
+| Search command message extension      | This sample shows how to incorporate a basic Message Extension app into a Microsoft Teams application using Bot Framework and Teams AI library.               | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/02.messageExtensions.a.searchCommand) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/02.teams-features/a.messageExtensions.searchCommand) | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/02.messageExtensions.a.searchCommand)    |
+| Typeahead bot                         | This sample shows how to incorporate the typeahead search functionality in Adaptive Cards into a Microsoft Teams application using Bot Framework and Teams AI library. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/03.adaptiveCards.a.typeAheadBot) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot) | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/03.adaptiveCards.a.typeAheadBot)       |
+| Conversational bot with AI: Teams chef | This sample shows how to incorporate conversational bot behavior into Microsoft Teams. The bot is built to allow GPT to facilitate the conversation on its behalf, using only a natural language prompt file to guide it. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.a.teamsChefBot)     | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/a.teamsChefBot)                 |                                                                                                              |
+| Message extensions: GPT-ME             | This sample is a message extension for Microsoft Teams that uses the text-davinci-003 model to help users generate and update posts.                           | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.b.messageExtensions.gptME) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/b.AI-messageExtensions)         | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.b.messageExtensions.AI-ME)         |
+| Light bot                             | This sample illustrates more complex conversational bot behavior in Microsoft Teams. The bot allows GPT to facilitate the conversation on its behalf with manually defined responses, mapping user intents to user-defined actions. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.c.actionMapping.lightBot) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/c.actionMapping-lightBot)       | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.c.actionMapping.lightBot)        |
+| List bot                              | This sample shows how to incorporate conversational bot behavior into Microsoft Teams. The bot harnesses the power of AI to simplify your workflow, bring order to your daily tasks, and showcases action chaining capabilities. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.d.chainedActions.listBot) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/d.chainedActions-listBot)        | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.d.chainedActions.listBot)        |
+| DevOps bot                            | This sample shows how to incorporate conversational bot behavior in Microsoft Teams. The bot uses the gpt-3.5-turbo model to chat with Teams users and perform DevOps actions such as create, update, triage, and summarize work items. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.ai.e.chainedActions.devOpsBot) | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/b.devOpsBot)                        | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.e.chainedActions.devOpsBot)        |
+| Twenty questions                      | This sample showcases the incredible capabilities of language models and the concept of user intent. Challenge your skills as a human player and try to guess a secret within 20 questions, while the AI-powered bot answers your queries about the secret. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/04.e.twentyQuestions)       | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/03.ai-concepts/a.twentyQuestions)              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/04.ai.a.twentyQuestions)                 |
+| Math tutor assistant                  | This example shows how to create a conversational experience using OpenAI's Assistants APIs. It uses OpenAI's Code Interpreter tool to create an assistant that's an expert on math. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/06.assistants.a.mathBot)     | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/d.assistants-mathBot)              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/06.assistants.a.mathBot)                |
+| Food ordering assistant               | This example shows how to create a conversational assistant that uses tools to call actions in your bot's code. It's a food ordering assistant for a fictional restaurant called The Pub and is capable of complex interactions with the user as it takes their order. | [View](https://github.com/microsoft/teams-ai/tree/main/dotnet/samples/06.assistants.b.orderBot)    | [View](https://github.com/microsoft/teams-ai/tree/main/js/samples/04.ai-apps/e.assistants-orderBot)              | [View](https://github.com/microsoft/teams-ai/tree/main/python/samples/06.assistants.b.orderBot)               |
 
 ## Next step
 
-> [!div class="nextstepaction"] > [Teams AI library quick start guide](conversation-ai-quick-start.md)
+> [!div class="nextstepaction"]
+> [Teams AI library quick start guide](conversation-ai-quick-start.md)
 
 ## See also
 
-- [Teams AI library v2 (preview)](/microsoftteams/platform/teams-ai-library/welcome/overview)
-- [Copilot handoff](../conversations/bot-copilot-handoff.md)
-- [Teams AI library FAQs](../../../teams-faq.md#teams-ai-library)
+* [Teams AI library v2 (preview)](/microsoftteams/platform/teams-ai-library/welcome/overview)
+* [Copilot handoff](../conversations/bot-copilot-handoff.md)
+* [Teams AI library FAQs](../../../teams-faq.md#teams-ai-library)


### PR DESCRIPTION
Updated the v1 Teams AI docs with a link to the new v2 docs.