### PR TITLE
Update description of Agent Identity Blueprint tool

### DIFF
--- a/msteams-platform/concepts/build-and-test/manage-your-apps-in-developer-portal.md
+++ b/msteams-platform/concepts/build-and-test/manage-your-apps-in-developer-portal.md
@@ -287,7 +287,7 @@ Create and manage Agent Identity Blueprints in Developer Portal, while manage ag
 
 #### View and use existing Agent Identity Blueprints
 
-The Agent Identity Blueprint tool in Developer Portal displays a list of existing blueprints available in your tenant.
+The Agent Identity Blueprint tool in Developer Portal displays a list of existing blueprints available in your tenant. While Blueprints are visible to all users in a tenant, only the owners of a blueprint can make changes to it.
 
 :::image type="content" source="../../assets/images/tdp/list-agent-blueprint.png" alt-text="List of available agent blueprints" lightbox="../../assets/images/tdp/list-agent-blueprint.png":::
 


### PR DESCRIPTION
Clarified that only owners can modify Agent Identity Blueprints.