### PR TITLE
Fix deep link format for chat messages

### DIFF
--- a/msteams-platform/concepts/build-and-test/deep-link-teams.md
+++ b/msteams-platform/concepts/build-and-test/deep-link-teams.md
@@ -3,9 +3,9 @@ title: Deep link to a Teams chat
 author: surbhigupta
 description: Learn how to create deep links to a Teams chat and navigate to a chat, channel, chat messages, team, and files in the channel in Microsoft Teams. 
 ms.topic: conceptual
-ms.author: surbhigupta
+ms.author: vikasalmal
 ms.localizationpriority: high
-ms.date: 01/31/2023
+ms.date: 03/26/2026
 ---
 
 # Deep link to Teams chat


### PR DESCRIPTION
Removed extraneous tenantId parameter from deep link format for chat messages.