### PR TITLE
RSC docs refresh

### DIFF
--- a/msteams-platform/graph-api/App-permissions/Teams-app-permissions.md
+++ b/msteams-platform/graph-api/App-permissions/Teams-app-permissions.md
@@ -5,7 +5,7 @@ ms.topic: reference
 ms.localizationpriority: medium
 ms.author: lomeybur
 ms.owner: vishachadha
-ms.date: 10/31/2022
+ms.date: 05/11/2026
 ---
 
 # Permissions in Teams app

--- a/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/grant-resource-specific-consent.md
@@ -5,7 +5,7 @@ ms.localizationpriority: medium
 ms.author: vikasalmal
 ms.topic: reference
 ms.owner: vishachadha
-ms.date: 02/27/2026
+ms.date: 05/11/2026
 ---
 
 # Grant RSC permissions to your app

--- a/msteams-platform/graph-api/rsc/preapproval-instruction-docs.md
+++ b/msteams-platform/graph-api/rsc/preapproval-instruction-docs.md
@@ -5,7 +5,7 @@ ms.localizationpriority: medium
 author: MSFTRickyCastaneda
 ms.author: rcastaneda
 ms.topic: conceptual
-ms.date: 08/29/2023
+ms.date: 05/11/2026
 ---
 
 # Preapproval of RSC permissions

--- a/msteams-platform/graph-api/rsc/resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/resource-specific-consent.md
@@ -4,7 +4,7 @@ description: Learn about resource-specific consent (RSC) permissions, types of R
 ms.localizationpriority: medium
 ms.topic: conceptual
 ms.owner: vishachadha
-ms.date: 02/20/2025
+ms.date: 05/11/2026
 ---
 
 # Resource-specific consent for your Teams app

--- a/msteams-platform/graph-api/rsc/test-resource-specific-consent.md
+++ b/msteams-platform/graph-api/rsc/test-resource-specific-consent.md
@@ -6,7 +6,7 @@ author: akjo
 ms.topic: tutorial
 ms.owner: vishachadha
 keywords: teams authorization OAuth SSO Microsoft Azure Active Directory (Azure AD) rsc Postman Graph
-ms.date: 03/28/2023
+ms.date: 05/11/2026
 ---
 
 # Test resource-specific consent permissions in Teams


### PR DESCRIPTION
Getting the five primary RSC docs into a PR for collaborative review and update.

ADO: None, this is being tracked in [this group chat](https://teams.microsoft.com/l/chat/19:58e66b7ddfe940ea8cb3f59fcf0d3f72@thread.v2/conversations?context=%7B%22contextType%22%3A%22chat%22%7D).

Previews:
- [Manage Teams app permissions](https://review.learn.microsoft.com/en-us/microsoftteams/platform/graph-api/app-permissions/teams-app-permissions?branch=pr-en-us-14313)
- [Grant RSC permissions to an app](https://review.learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/grant-resource-specific-consent?branch=pr-en-us-14313)
- [Preapproval of RSC permissions](https://review.learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/preapproval-instruction-docs?branch=pr-en-us-14313)
- [Resource-specific consent for apps](https://review.learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent?branch=pr-en-us-14313)
- [Test RSC Permissions in Teams](https://review.learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/test-resource-specific-consent?branch=pr-en-us-14313)