### PR TITLE
Comments on updating "Get Teams specific context for your bot" to Teams SDK

### DIFF
--- a/msteams-platform/bots/how-to/get-teams-context.md
+++ b/msteams-platform/bots/how-to/get-teams-context.md
@@ -4,7 +4,7 @@ description: Get Teams specific context for your bot, fetch user profile, get si
 ms.topic: article
 ms.localizationpriority: high
 ms.owner: angovil
-ms.date: 03/16/2026
+ms.date: 05/29/2026
 ---
 # Get Teams specific context for your bot
 


### PR DESCRIPTION
Updating "Get Teams specific context for your bot" from Bot Framework to Teams SDK.

[Current live page](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/get-teams-context); [rendered preview of this PR](https://review.learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/get-teams-context?branch=pr-en-us-14390)

Context: (see [this thread](https://teams.microsoft.com/l/message/19:a6a98b2dd37b49888f40b0f99180c452@thread.tacv2/1779726885228?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=1314f851-c930-4caa-b3e0-dbe9b8fe2737&parentMessageId=1779726885228&teamName=Spark%20%F0%9F%94%A5&channelName=OnCall%20Issues&createdTime=1779726885228)) A recent customer issue involved use of the Teams SDK in .NET, which was found to be using the older unpaginated versions of the GetMembers API (get members of chat). This led to the realization that this whole situation is not well documented: [Get Teams specific context for your bot](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/get-teams-context) appears to the canonical page for doing this, and it does cover the deprecation, but it's all in Bot Framework. This is a good opportunity to just convert this whole page to Teams SDK.



TODO:

- Consider zone pivots instead of tabs
- Retire [Use Bot API to Fetch Team/Chat members](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/team-chat-member-api-changes) and redirect it to "Get Teams specific context". This page is a point-in-time article about the old APIs becoming deprecated _in bot Framework_ in _2021/2022._ Also find any links to this page and update them.