### PR TITLE
[Doc Improvement] Deprecation notice for Teams Together and Scene Studio in Developer portal

### DIFF
--- a/msteams-platform/apps-in-teams-meetings/teams-together-mode.md
+++ b/msteams-platform/apps-in-teams-meetings/teams-together-mode.md
@@ -10,7 +10,7 @@ ms.date: 06/22/2026
 # Custom Together Mode scenes in Teams
 
 > [!IMPORTANT]
-> Custom Together Mode and Scene Studio in the Teams Developer Portal are being deprecated as of June 30, 2026. For more information, see the [announcement](https://techcommunity.microsoft.com/blog/microsoft365insiderblog/goodbye-together-mode-hello-simplified-meeting-layouts-in-microsoft-teams/4519312).
+> Together Mode, including Custom Together Mode and Scene Studio in the Teams Developer Portal, is being deprecated as of June 30, 2026. For more information, see the [announcement](https://techcommunity.microsoft.com/blog/microsoft365insiderblog/goodbye-together-mode-hello-simplified-meeting-layouts-in-microsoft-teams/4519312).
 
 > [!NOTE]
 >

--- a/msteams-platform/apps-in-teams-meetings/teams-together-mode.md
+++ b/msteams-platform/apps-in-teams-meetings/teams-together-mode.md
@@ -4,10 +4,13 @@ description: Learn how to work with custom Together Mode scenes in Microsoft Tea
 ms.topic: article
 ms.localizationpriority: high
 ms.owner: kartikd
-ms.date: 04/07/2022
+ms.date: 06/22/2026
 ---
 
 # Custom Together Mode scenes in Teams
+
+> [!IMPORTANT]
+> Custom Together Mode and Scene Studio in the Teams Developer Portal are being deprecated as of June 30, 2026. For more information, see the [announcement](https://techcommunity.microsoft.com/blog/microsoft365insiderblog/goodbye-together-mode-hello-simplified-meeting-layouts-in-microsoft-teams/4519312).
 
 > [!NOTE]
 >

--- a/msteams-platform/whats-new.md
+++ b/msteams-platform/whats-new.md
@@ -36,9 +36,9 @@ Discover Microsoft Teams platform features that are generally available (GA). Yo
 
 Teams platform features that are available to all app developers.</br>
 
-**2026 April**
+**2026 June**
 
-* ***April 27, 2026***: [Prompt starters are now generally available.](bots/how-to/conversations/prompt-suggestions.md)
+* ***June 22, 2026***: Custom Together Mode and Scene Studio in Teams Developer Portal are being deprecated as of June 30, 2026. For more information, see the [announcement](https://techcommunity.microsoft.com/blog/microsoft365insiderblog/goodbye-together-mode-hello-simplified-meeting-layouts-in-microsoft-teams/4519312).
 
 :::column-end:::
 :::row-end:::
@@ -51,6 +51,7 @@ Teams platform features that are available to all app developers.</br>
 
 | **Date** | **Update** | **Find here** |
 | -------- | --------- | ---------------- |
+| 27/04/2026 | Support for Prompt starters are now generally available | [Prompt starters are now generally available.](bots/how-to/conversations/prompt-suggestions.md) |
 | 27/01/2026 | Support for apps in Private channels. | [Enable apps for shared and private channels](build-apps-for-shared-private-channels.md) |
 
 <br/>

--- a/msteams-platform/whats-new.md
+++ b/msteams-platform/whats-new.md
@@ -38,7 +38,7 @@ Teams platform features that are available to all app developers.</br>
 
 **2026 June**
 
-* ***June 22, 2026***: Custom Together Mode and Scene Studio in Teams Developer Portal are being deprecated as of June 30, 2026. For more information, see the [announcement](https://techcommunity.microsoft.com/blog/microsoft365insiderblog/goodbye-together-mode-hello-simplified-meeting-layouts-in-microsoft-teams/4519312).
+* ***June 22, 2026***: Together Mode, including Custom Together Mode and Scene Studio in the Teams Developer Portal, is being deprecated as of June 30, 2026. For more information, see the [announcement](https://techcommunity.microsoft.com/blog/microsoft365insiderblog/goodbye-together-mode-hello-simplified-meeting-layouts-in-microsoft-teams/4519312).
 
 :::column-end:::
 :::row-end:::


### PR DESCRIPTION
**ADO**: [Documentation 5484477](https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/5484477): [Doc Feature] Together Mode retirement
This task involves adding a deprecation note for Teams Together and Scene Studio in the Developer portal, as well as a corresponding what's new entry.
**Preview link**: https://review.learn.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/teams-together-mode?branch=pr-en-us-14441