### PR TITLE
Remove agent reactions public preview note

### DIFF
--- a/msteams-platform/agents-in-teams/agent-reactions.md
+++ b/msteams-platform/agents-in-teams/agent-reactions.md
@@ -13,10 +13,6 @@ zone_pivot_groups: teams-sdk-languages
 
 # Use emoji reactions in Teams chat
 
-> [!NOTE]
->
-> Support for agent reactions in Teams is available in [public developer preview](../resources/dev-preview/developer-preview-intro.md).
-
 In Teams chat, reactions are lightweight emoji markers that participants can attach to anyone's messages. Agents can use reactions to acknowledge messages, display workflow status, and present other information without interrupting the flow of the conversation. Agents can also listen for and respond to reactions.
 
 # [Desktop](#tab/desktop)

--- a/msteams-platform/agents-in-teams/agent-reactions.md
+++ b/msteams-platform/agents-in-teams/agent-reactions.md
@@ -3,7 +3,7 @@ title: Build Agents that Use Emoji Reactions in Teams Chat
 description: Reactions are emoji markers on messages in Teams chat. Learn how to make an agent that adds, removes, and listens reactions with practical code examples.
 #customer intent: As a Teams agent developer, I want to add emoji reactions to chat messages so that my agent can acknowledge messages without interrupting the conversation.
 ms.localizationpriority: high
-ms.date: 07/01/2026
+ms.date: 07/10/2026
 author: nickwalkmsft
 ms.author: nickwalk
 ms.reviewer: nickwalk

--- a/msteams-platform/agents-in-teams/teams-reactions-reference.md
+++ b/msteams-platform/agents-in-teams/teams-reactions-reference.md
@@ -2,7 +2,7 @@
 title: Teams Emoji Reactions Reference
 description: Use the emojis available for Teams agents reactions.
 ms.topic: reference
-ms.date: 01/23/2026
+ms.date: 07/10/2026
 ms.localizationpriority: high
 ---
 

--- a/msteams-platform/agents-in-teams/teams-reactions-reference.md
+++ b/msteams-platform/agents-in-teams/teams-reactions-reference.md
@@ -8,10 +8,6 @@ ms.localizationpriority: high
 
 # Teams Reactions Reference
 
-> [!NOTE]
->
-> Support for agent reactions in Teams is available in [public developer preview](../resources/dev-preview/developer-preview-intro.md).
-
 This article provides a complete list of emoji reactions available in Teams and their corresponding reaction IDs, used to [add reactions to messages](agent-reactions.md).
 
 ## Skin tones


### PR DESCRIPTION
## Summary
- remove the public developer preview note from agent reactions documentation
- update both reactions overview and reactions reference pages

## Files changed
- msteams-platform/agents-in-teams/agent-reactions.md
- msteams-platform/agents-in-teams/teams-reactions-reference.md

## Validation
- searched the repo for the exact sentence and confirmed no remaining matches