### PR TITLE
Add WIQD awareness to declarative agent docs

### DIFF
--- a/msteams-platform/concepts/deploy-and-publish/appsource/prepare/review-copilot-validation-guidelines.md
+++ b/msteams-platform/concepts/deploy-and-publish/appsource/prepare/review-copilot-validation-guidelines.md
@@ -6,7 +6,7 @@ author: v-preethah
 ms.author: vikasalmal
 ms.localizationpriority: high
 ms.owner: ginobuzz
-ms.date: 05/11/2026
+ms.date: 08/05/2026
 ms.collection: ce-skilling-ai-copilot
 ---
 
@@ -23,6 +23,9 @@ These guidelines are applicable for Independent Software Vendors (ISV) who want 
 This section is in line with [Microsoft commercial marketplace policy number 1140.9](/legal/marketplace/certification-policies#11409-copilot-extensions-for-copilot-for-microsoft-365).
 
 Apps must be consistent with responsible [AI checks](teams-store-validation-guidelines.md#apps-with-ai-generated-content).
+
+> [!TIP]
+> [Work IQ Dev Tools (WIQD)](https://aka.ms/wiqd/docs) is in preview and provides fast schema validation for a Microsoft 365 Copilot declarative agent, with optional deep semantic checks for manifest issues, external references, and API plugin schemas. Use it to identify issues early; it complements rather than replaces these policy and experience requirements.
 
 :::row:::
    :::column span="":::

--- a/msteams-platform/concepts/deploy-and-publish/appsource/publish.md
+++ b/msteams-platform/concepts/deploy-and-publish/appsource/publish.md
@@ -4,7 +4,7 @@ description: Publish your app to Microsoft Teams Store or AppSource. What to exp
 ms.topic: overview
 author: heath-hamilton
 ms.localizationpriority: high
-ms.date: 12/15/2022
+ms.date: 08/05/2026
 ---
 # Publish your app to the Teams Store
 
@@ -24,6 +24,9 @@ If your app is production ready, you can begin the process of getting it listed 
 
 > [!TIP]
 > Following the pre-submission steps closely can increase the possibility that Microsoft approves your app for publishing.
+
+> [!NOTE]
+> [Work IQ Dev Tools (WIQD)](https://aka.ms/wiqd/docs) is in preview and can simplify validation and packaging for a Microsoft 365 Copilot declarative agent before you follow the Teams Store and Partner Center submission process. WIQD doesn't submit an agent to the public Teams Store or Partner Center.
 
 :::image type="content" source="../../../assets/images/submission/teams-app-store-publish-process.png" alt-text="Diagram shows the Teams Store publishing process for Teams apps." lightbox="../../../assets/images/submission/teams-app-store-publish-process.png":::
 

--- a/msteams-platform/toolkit/Microsoft-365-Agents-Toolkit-CLI.md
+++ b/msteams-platform/toolkit/Microsoft-365-Agents-Toolkit-CLI.md
@@ -5,7 +5,7 @@ description: Learn about Microsoft 365 Agents Toolkit Command Line Interface for
 ms.author: zhany
 ms.localizationpriority: medium
 ms.topic: overview
-ms.date: 05/16/2025
+ms.date: 08/05/2026
 ---
 
 # Microsoft 365 Agents Toolkit command line interface
@@ -22,6 +22,9 @@ Whether you prefer keyboard-centric developer operations, or you are automating 
 - **Resource Provisioning and Deployment**: Provision necessary cloud resources and deploy your application to Azure.
 - **Validation, Packaging, and Publishing**: Validate, package, and publish your agent or application using CLI commands.
 - **Environment Management**: Manage multiple environments, Microsoft Entra apps, and Teams app registration.
+
+> [!NOTE]
+> [Work IQ Dev Tools (WIQD)](https://aka.ms/wiqd/docs) is in preview and provides a workflow focused on Microsoft 365 Copilot declarative agents, built on Microsoft 365 Agents Toolkit capabilities. It brings creation, validation, packaging, provisioning, and sharing into one CLI lifecycle, including publishing to the organization catalog.
 
 ## Get started
 

--- a/msteams-platform/toolkit/overview-agents-toolkit.md
+++ b/msteams-platform/toolkit/overview-agents-toolkit.md
@@ -2,7 +2,7 @@
 title: Microsoft 365 Agents Toolkit
 description: Microsoft 365 Agents Toolkit is a suite of tools for building enterprise-ready agents that work across Microsoft 365 Copilot, Teams, web, and other third-party messaging channels.
 ms.topic: overview
-ms.date: 01/26/2026
+ms.date: 08/05/2026
 ---
 # Microsoft 365 Agents Toolkit
 
@@ -23,6 +23,9 @@ Microsoft 365 Agents Toolkit is available in the following formats:
 | :::image type="content" source="../assets/images/agents-toolkit-landing/vscode.png" alt-text="Visual Studio Code logo":::| Visual Studio Code | Agents Toolkit extension optimized for TypeScript and JavaScript development. | [Install Agents Toolkit for VS Code](install-teams-toolkit.md) |
 | :::image type="content" source="../assets/images/agents-toolkit-landing/visual-studio.png" alt-text="Visual Studio logo"::: | Visual Studio | Agents Toolkit workload optimized for .NET development. | [Install Agents Toolkit for Visual Studio](toolkit-v4/install-teams-toolkit-vs.md) |
 | :::image type="content" source="../assets/images/agents-toolkit-landing/terminal.png" alt-text="Icon of text-bsaed terminal"::: | CLI | Text-based interface to Agents Toolkit for the terminal or CI/CD processes.| [Agents Toolkit command line interface](teams-toolkit-cli.md) |
+
+> [!NOTE]
+> [Work IQ Dev Tools (WIQD)](https://aka.ms/wiqd/docs) is in preview and provides a command-line experience for Microsoft 365 Copilot declarative agents, built on Microsoft 365 Agents Toolkit capabilities. It brings creation, validation, packaging, provisioning, and sharing into one workflow, including publishing to the organization catalog. Use Agents Toolkit for the broader range of agent and app types.
 
 ## Deploy to multiple channels with Microsoft 365 Agents SDK
 


### PR DESCRIPTION
## Summary

- Add contextual WIQD preview guidance to Teams Store publishing preparation for declarative-agent validation and packaging.
- Connect WIQD static and deep validation capabilities to the Agent Store validation guidelines without replacing policy review.
- Introduce WIQD as a declarative-agent-focused lifecycle built on Microsoft 365 Agents Toolkit capabilities.
- Add WIQD alongside the CLI format in the Microsoft 365 Agents Toolkit overview while preserving Agents Toolkit's broader app and agent scope.

## Grounding

The notes are grounded in the public WIQD getting-started and CLI documentation, with the internal `gim-home/wiqd` repository used only for source verification. Public Learn content links only to `https://aka.ms/wiqd/docs`.

## Scope

Updates only the four requested Microsoft Teams developer documentation articles.