### PR TITLE
Consolidate OAuth and Microsoft Entra guidance for MCP agent connector authentication

### DIFF
--- a/msteams-platform/m365-apps/agent-connectors.md
+++ b/msteams-platform/m365-apps/agent-connectors.md
@@ -2,7 +2,7 @@
 title: Register MCP Servers as Agent Connectors for Microsoft 365
 description: Register your MCP server in the Microsoft 365 app manifest to enable access to your tools from agents in Teams.
 #customer intent: As a developer, I want to register my MCP server as an agent connector so that Microsoft 365 agents can access my external tools and services.
-ms.date: 06/19/2026
+ms.date: 08/28/2026
 ms.topic: how-to
 ms.subservice: m365apps
 ---
@@ -91,7 +91,7 @@ Specify how Microsoft 365 retrieves credentials when calling your MCP server. Th
 - **OAuthPluginVault**: OAuth 2.0 tokens stored inside Microsoft’s secure vault
 - **ApiKeyPluginVault**: API key stored in a vault and referenced by ID
 - **DynamicClientRegistration**: Dynamic OAuth client registration
-- **AzureKeyVault**: Secrets stored in your own Azure Key Vault instance
+- **AzureKeyVault**: Secrets stored in your own Azure Key Vault instance. Available only in the `devPreview` manifest schema and not valid in a numbered schema version.
 
 ### Use OAuth authentication
 
@@ -126,6 +126,9 @@ The `referenceId` points to an [API key that you register in Developer Portal](h
 
 ### Use dynamic client registration
 
+> [!WARNING]
+> Dynamic client registration isn't available for an MCP server that's protected by Microsoft Entra ID. Microsoft Entra ID doesn't publish an [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) registration endpoint, so there's nothing for Microsoft 365 to register a client against. For a server that's protected by Microsoft Entra ID, register the OAuth client statically instead. For more information, see [Configure OAuth in Developer Portal](../messaging-extensions/api-based-oauth.md#configure-oauth-in-developer-portal) and [Configure OAuth 2.0 authentication](/microsoft-365-copilot/extensibility/plugin-authentication-oauth).
+
 Dynamic client registration enables Microsoft 365 to register as an OAuth client with your MCP server at runtime using the [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) protocol. This approach is useful when your server supports dynamic OAuth flows and you don't want to pre-register client credentials.
 
 Configure the authorization type as `DynamicClientRegistration` with a `referenceId`:
@@ -146,6 +149,9 @@ Your server must:
 - Support token refresh for long-lived sessions.
 
 ### Use Azure Key Vault authentication
+
+> [!WARNING]
+> `AzureKeyVault` is available only in the `devPreview` manifest schema. A package that targets a numbered schema version, such as `1.27`, fails validation if it sets `"type": "AzureKeyVault"`. For production, use `OAuthPluginVault` or `DynamicClientRegistration` instead.
 
 Azure Key Vault authentication allows you to store and manage your MCP server credentials in your own [Azure Key Vault](/azure/key-vault/general/overview) instance. This gives you full control over secret lifecycle management, including rotation, access policies, and audit logging.
 
@@ -175,7 +181,9 @@ For enterprise scenarios, prefer OAuth over API keys to align with security best
 
 ## Define tool discovery
 
-Configure how Microsoft 365 agents discover the tools your MCP server provides. Use static inline tool definitions when your toolset is stable, or enable dynamic tool discovery when your toolset changes frequently.
+Configure how Microsoft 365 agents discover the tools your MCP server provides. Define your tools explicitly with static inline definitions whenever you can, and reserve dynamic tool discovery for a server you don't control.
+
+We recommend static tool definitions for most apps, and especially for apps that you publish or submit for certification. Because the tool names, descriptions, and input schemas are declared in your app package, they're reviewable at validation time and can't change after you publish. With dynamic discovery, the tool list isn't visible until runtime, and a server that later changes its `tools/list` response changes what your published app exposes. If a coding toolkit or harness already regenerates and republishes your package when tools change, the "no republish" benefit of dynamic discovery mostly disappears - so the main reason to use it is a server owned by another team or organization whose toolset changes outside your release process, where coordinating a republish isn't practical.
 
 ### Use static tool definitions
 
@@ -198,9 +206,11 @@ For static toolsets that don't change frequently, add an `mcpToolDescription` ob
 
 The `description` object must match the schema returned by your MCP server's `tools/list` response.
 
+The `file` value must be a plain relative path from the app package root, such as `toolDescription.json` or `tools/toolDescription.json`. Don't use a `./` prefix, an absolute path, or a traversing path (`../`), because the packaging step derives the archive entry directly from the raw string.
+
 ### Use dynamic tool discovery
 
-Dynamic tool discovery allows Microsoft 365 agents to fetch your tool list at runtime by calling your server's `tools/list` method. This approach is recommended when your toolset changes frequently, as it eliminates the need to republish your app each time tools are added, updated, or removed.
+Dynamic tool discovery allows Microsoft 365 agents to fetch your tool list at runtime by calling your server's `tools/list` method. Use it when you don't own the MCP server and its toolset changes outside your release process, so republishing your app for every change isn't practical. For a server you control, prefer [static tool definitions](#use-static-tool-definitions) so the tools are reviewable at publish time and can't change after certification.
 
 To enable dynamic tool discovery, omit the [mcpToolDescription](/microsoft-365/extensibility/schema/root-agent-connectors-tool-source-remote-mcp-server-mcp-tool-description) from your [remoteMcpServer](/microsoft-365/extensibility/schema/root-agent-connectors-tool-source-remote-mcp-server) configuration:
 

--- a/msteams-platform/messaging-extensions/api-based-oauth.md
+++ b/msteams-platform/messaging-extensions/api-based-oauth.md
@@ -2,8 +2,8 @@
 title: OAuth for API based Message Extension
 description: Learn about the requirements for implementing OAuth for an API based message extension and its limitation and best practices.
 ms.localizationpriority: medium
-ms.topic: overview
-ms.date: 04/03/2025
+ms.topic: how-to
+ms.date: 08/28/2026
 ---
 
 # Enable OAuth authentication for API based message extension
@@ -53,8 +53,8 @@ To enable OAuth for your API based message extension:
 Before you start, you must have:
 
 * A Microsoft Teams app with API Message Extensions or Plugins.
-* An OAuth 2.0 client ID and client secret from the third-party authorization server.
-* When setting up your OAuth app with a third-party authentication provider, ensure that you add <https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect> to the list of allowed redirect endpoints. These providers maintain a list of such endpoints to call for their app, making it crucial to include this URL to ensure seamless functionality.
+* An OAuth 2.0 client ID and, for a confidential client, a client secret from the third-party authorization server. A public client that uses PKCE (a single-page application platform) doesn't require a client secret.
+* When setting up your OAuth app with a third-party authentication provider, ensure that you add <https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect> to the list of allowed redirect endpoints. This redirect URI is fixed: it's the same for every app and every provider, and you can't customize it for your app. If you don't add it to the provider's list of allowed redirect endpoints, sign-in fails.
 
 ### Configure OAuth in Developer Portal
 
@@ -96,6 +96,9 @@ To register OAuth for your API based message extensions, follow these steps:
           | **Any Teams app** | When you develop your app in your tenant and test the app as a custom app or custom app built for your organization. | The API key can be used with any Teams app. It's useful when custom app or custom app built for your organization have IDs generated after app upload. |
           |**Existing Teams app ID** | After you've completed testing your app within your tenant as a custom app or custom app built for your organization. <br> Update your API key registration and select **Existing Teams app** and input your app’s manifest ID. | The **Existing Teams app** option binds the API secret registration to your specific Teams app. |
 
+      > [!IMPORTANT]
+      > If you use this OAuth client registration for a Model Context Protocol (MCP) server that's registered as an agent connector, select **Any Teams app**. Microsoft 365 Copilot doesn't resolve a Teams app ID for an agent connector, so a registration that's bound to **Existing Teams app ID** provisions successfully and then returns a `404` error on every tool call. If you provision the registration with Microsoft 365 Agents Toolkit, the equivalent setting in the `oauth/register` action in `m365agents.yml` is `applicableToApps: AnyApp`. Keep the `appId` field in that action even though `AnyApp` makes it inert, because the provisioning driver validates `appId` unconditionally.
+
 1. Under **OAuth settings**, update the following:
 
     :::image type="content" source="../assets/images/Copilot/api-based-me-oauth-oauthsettings.png" alt-text="Screenshots shows the OAuth settings required for oauth configuration ID in Developer Portal for Teams":::
@@ -112,11 +115,16 @@ To register OAuth for your API based message extensions, follow these steps:
 
    1. **Scope**: *[Optional]* The scope defines the permissions your app requests from the user.
 
+   Proof Key for Code Exchange (PKCE) is enabled by default, because many organizations block client secrets. Turn PKCE off only if your authorization server doesn't support it. To avoid client secrets entirely, register a public client with your provider, a single-page application platform rather than a Web platform, and let PKCE secure the code exchange.
+
 1. Select **Save**.
 
    An **OAuth client registration ID** is generated.
 
    :::image type="content" source="../assets/images/Copilot/api-based-me-oauth-registration-id.png" alt-text="Screenshot shows the OAuth client registration ID generated in Developer POrtal for Teams.":::
+
+   > [!NOTE]
+   > Developer Portal is the only place where you can delete an OAuth client registration. If you create registrations by provisioning with Microsoft 365 Agents Toolkit, the `oauth/register` action only creates a registration or skips it: when `configurationId` already has a value, the action does nothing, and when it points to a registration that was deleted, the action warns you and does nothing. Use the `oauth/update` action to change the values in an existing registration.
 
 ### Add OAuth client registration ID in API based message extension
 


### PR DESCRIPTION
## Summary

Consolidates OAuth 2.0 + Microsoft Entra ID requirements for **MCP servers registered as agent connectors** (used by Microsoft 365 Copilot), removing loose ends that pointed developers at configurations that fail after a successful provision.

## Changes

**`messaging-extensions/api-based-oauth.md`**
- Documents selecting **Any Teams app** for an MCP agent connector, and why **Existing Teams app ID** provisions successfully then returns `404` on every tool call (Copilot doesn't resolve a Teams app ID for an agent connector). Includes the Agents Toolkit equivalent `applicableToApps: AnyApp` and why `appId` must stay.
- Clarifies the redirect URI is fixed and non-customizable.
- PKCE enabled by default + secretless public-client variant; client secret qualified as confidential-client-only.
- `oauth/register` create-or-skip behavior and Developer Portal as the only delete surface.
- `ms.topic` changed `overview` -> `how-to` (article is a step-by-step procedure).

**`m365-apps/agent-connectors.md`**
- Scopes `AzureKeyVault` to the `devPreview` schema only (a numbered schema version fails validation).
- Adds the DCR-vs-Microsoft Entra warning (no RFC 7591 endpoint).
- Tool-description `file` must be a plain relative path from the app package root (no `./` prefix, absolute, or traversing path), because packaging derives the archive entry from the raw string.
- Recommends explicit static tool definitions for owned/published servers (reviewable at certification, immutable post-publish) and scopes dynamic discovery to servers you don't control.

## Notes for reviewers
- Draft, from fork `rloutlaw/msteams-docs`. Companion PR in `m365copilot-docs-pr`.
- `ms.date` updated. markdownlint clean on changed files (2 pre-existing MD060 table errors in `api-based-oauth.md` are unrelated and untouched).
