### PR TITLE
Removing metered API instances from DevDocs

### DIFF
--- a/msteams-platform/graph-api/meeting-transcripts/overview-transcripts.md
+++ b/msteams-platform/graph-api/meeting-transcripts/overview-transcripts.md
@@ -10,8 +10,9 @@ ms.date: 09/07/2026
 
 # Get meeting transcripts and recordings using Graph APIs
 
-> [!NOTE]
-> The APIs to fetch meeting transcripts and recordings are metered APIs. For more information, see [payment models for meeting APIs](/graph/teams-licenses#payment-models-for-meeting-apis).
+> [!IMPORTANT]
+>
+> Starting August 25, 2025, the Teams APIs listed in this article are no longer metered, and no billing configuration is required to use these APIs. If your application is configured for billing, no action is required. This article is provided for reference as the final billing cycle for metered Microsoft Teams APIs concludes.
 
 You can now configure your app to fetch Microsoft Teams transcripts and recordings after the meeting or call ends. Your app can use Microsoft Graph REST APIs to access and fetch transcripts and recordings generated for the following instances:
 

--- a/msteams-platform/graph-api/meeting-transcripts/overview-transcripts.md
+++ b/msteams-platform/graph-api/meeting-transcripts/overview-transcripts.md
@@ -5,7 +5,7 @@ ms.localizationpriority: high
 ms.topic: article
 ms.owner: vichug
 ms.author: nickwalk
-ms.date: 06/30/2026
+ms.date: 09/07/2026
 ---
 
 # Get meeting transcripts and recordings using Graph APIs


### PR DESCRIPTION
Description: Removing metered API instances
ADO: https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/5771032/?view=edit
Preview: https://review.learn.microsoft.com/en-us/microsoftteams/platform/graph-api/meeting-transcripts/overview-transcripts?branch=pr-en-us-14597